### PR TITLE
Maryia/BOT-379/fix: Switch to Trader's Hub CTA routes to Mt5 first

### DIFF
--- a/packages/shared/src/utils/digital-options/digital-options.ts
+++ b/packages/shared/src/utils/digital-options/digital-options.ts
@@ -36,7 +36,7 @@ export const showDigitalOptionsUnavailableError = (
         redirect_label: link,
         redirectOnClick,
         should_show_refresh: false,
-        redirect_to: '/mt5',
+        redirect_to: '/appstore/traders-hub',
         should_clear_error_on_click,
         should_redirect,
     });


### PR DESCRIPTION
## Changes:

fix: Switch to Trader's Hub CTA routes to Mt5 first

### Screenshots:

Please provide some screenshots of the change.
