### PR TITLE
Implement Manual Document Upload Hook inside POIncome

### DIFF
--- a/packages/account/src/Sections/Verification/ProofOfIncome/__tests__/proof-of-income.spec.tsx
+++ b/packages/account/src/Sections/Verification/ProofOfIncome/__tests__/proof-of-income.spec.tsx
@@ -36,12 +36,16 @@ jest.mock('@deriv/shared', () => ({
                 })
             ),
         },
-        getSocket: jest.fn(() => Promise.resolve()),
     },
 }));
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     Redirect: jest.fn(() => <div>Redirect</div>),
+}));
+
+jest.mock('@deriv/api', () => ({
+    ...jest.requireActual('@deriv/api'),
+    useDocumentUpload: jest.fn(() => ({ mutate: jest.fn() })),
 }));
 
 describe('ProofOfIncome', () => {

--- a/packages/account/src/Sections/Verification/ProofOfIncome/proof-of-income-form.tsx
+++ b/packages/account/src/Sections/Verification/ProofOfIncome/proof-of-income-form.tsx
@@ -9,7 +9,6 @@ import {
     MobileWrapper,
     SelectNative,
 } from '@deriv/components';
-// import { useFileUploader } from '@deriv/hooks';
 import { localize, Localize } from '@deriv/translations';
 import { isEqualArray, WS } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';

--- a/packages/account/src/Sections/Verification/ProofOfIncome/proof-of-income-form.tsx
+++ b/packages/account/src/Sections/Verification/ProofOfIncome/proof-of-income-form.tsx
@@ -35,7 +35,6 @@ type TInitialValues = {
 const ProofOfIncomeForm = observer(({ onSubmit }: TProofOfIncomeForm) => {
     const [document_file, setDocumentFile] = React.useState<File[]>([]);
     const [file_selection_error, setFileSelectionError] = React.useState<string | null>(null);
-    const [uploadResponses, setUploadResponses] = React.useState(0);
 
     const poinc_documents_list = React.useMemo(() => getPoincDocumentsList(), []);
     const poinc_uploader_files_descriptions = React.useMemo(() => getFileUploaderDescriptions('poinc'), []);
@@ -44,12 +43,11 @@ const ProofOfIncomeForm = observer(({ onSubmit }: TProofOfIncomeForm) => {
     const { addNotificationMessageByKey, removeNotificationMessage, removeNotificationByKey } = notifications;
     const { isMobile, isDesktop } = useDevice();
 
-    const { upload, data } = useDocumentUpload();
+    const { upload, data, documentUploadStatus } = useDocumentUpload();
 
     React.useEffect(() => {
         const fetchAccountStatus = async () => {
-            if (uploadResponses === 1) {
-                await new Promise(resolve => setTimeout(resolve, 3000)); // Wait for 3s so that second response from doc uploader is received
+            if (documentUploadStatus === 'success') {
                 const get_account_status_response: DeepRequired<AccountStatusResponse> =
                     await WS.authorized.getAccountStatus();
                 const { income, needs_verification } =
@@ -68,7 +66,7 @@ const ProofOfIncomeForm = observer(({ onSubmit }: TProofOfIncomeForm) => {
             }
         };
         fetchAccountStatus();
-    }, [uploadResponses]);
+    }, [documentUploadStatus]);
 
     const initial_form_values: TInitialValues = {
         document_type: '',
@@ -96,7 +94,6 @@ const ProofOfIncomeForm = observer(({ onSubmit }: TProofOfIncomeForm) => {
             setSubmitting(true);
             try {
                 await upload({ file: document_file[0], document_type: uploading_value });
-                setUploadResponses(prev => prev + 1);
 
                 if ('warning' in data) {
                     setStatus({ msg: data.status });

--- a/packages/api/src/hooks/useDocumentUpload.ts
+++ b/packages/api/src/hooks/useDocumentUpload.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import useMutation from '../useMutation';
 import { compressImageFile, generateChunks, numToUint8Array, readFile } from '../utils';
 import md5 from 'md5';
-import { getActiveWebsocket } from '../APIProvider';
+import { useAPIContext } from '../APIProvider';
 
 type TDocumentUploadPayload = Parameters<ReturnType<typeof useMutation<'document_upload'>>['mutate']>[0]['payload'];
 type TUploadPayload = Omit<TDocumentUploadPayload, 'document_format' | 'expected_checksum' | 'file_size'> & {
@@ -20,7 +20,7 @@ const useDocumentUpload = () => {
         ...rest
     } = useMutation('document_upload');
     const [isDocumentUploaded, setIsDocumentUploaded] = useState(false);
-    const activeWebSocket = getActiveWebsocket();
+    const { derivAPI } = useAPIContext();
 
     const isLoading = _isLoading || (!isDocumentUploaded && status === 'success');
     const isSuccess = _isSuccess && isDocumentUploaded;
@@ -56,12 +56,12 @@ const useDocumentUpload = () => {
                 chunks.forEach(chunk => {
                     const size = numToUint8Array(chunk.length);
                     const payload = new Uint8Array([...type, ...id, ...size, ...chunk]);
-                    activeWebSocket?.send(payload);
+                    derivAPI.connection.send(payload);
                 });
                 setIsDocumentUploaded(true);
             });
         },
-        [activeWebSocket, mutateAsync]
+        [derivAPI, derivAPI.connection, mutateAsync]
     );
 
     const modified_response = useMemo(() => ({ ...data?.document_upload }), [data?.document_upload]);

--- a/packages/api/src/hooks/useDocumentUpload.ts
+++ b/packages/api/src/hooks/useDocumentUpload.ts
@@ -70,23 +70,21 @@ const useDocumentUpload = () => {
                     if (data.error) {
                         derivAPI.connection?.removeEventListener('message', handleUploadStatus);
                         setDocumentUploadStatus('error');
-                        clearTimeout(timeout);
                         return;
                     }
 
                     if (data.document_upload && data.document_upload?.status === 'failure') {
                         derivAPI.connection?.removeEventListener('message', handleUploadStatus);
                         setDocumentUploadStatus('failure');
-                        clearTimeout(timeout);
                         return;
                     }
 
                     if (data.document_upload && data.document_upload?.status === 'success') {
                         derivAPI.connection?.removeEventListener('message', handleUploadStatus);
                         setDocumentUploadStatus('success');
-                        clearTimeout(timeout);
                     }
                 };
+                clearTimeout(timeout);
 
                 derivAPI.connection?.addEventListener('message', handleUploadStatus);
 


### PR DESCRIPTION
## Changes:
- This PR implements a hook `useDocumentUpload` for Proof of Income. The hook will replace the current implementation for uploading documents using BinaryDocumentUploader library. 

### Screenshots:

https://github.com/user-attachments/assets/c85eaf40-a90e-4067-b863-03e26c5a3521


