### PR TITLE
[BOT] sandeep/bot-2154/fix: sync on focus server-bot

### DIFF
--- a/packages/bot-web-ui/src/pages/server-side-bot/bot-list/bot-list.tsx
+++ b/packages/bot-web-ui/src/pages/server-side-bot/bot-list/bot-list.tsx
@@ -42,6 +42,11 @@ const BotList: React.FC<TBotList> = observer(({ setFormVisibility }) => {
 
     useEffect(() => {
         if (should_subscribe) getBotList();
+
+        window.addEventListener('focus', getBotList);
+        return () => {
+            window.removeEventListener('focus', getBotList);
+        };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 

--- a/packages/bot-web-ui/src/stores/server-side-bot-store.ts
+++ b/packages/bot-web-ui/src/stores/server-side-bot-store.ts
@@ -492,6 +492,7 @@ export default class ServerBotStore {
 
     subscribeToBotNotification = async (bot_id: string) => {
         try {
+            if (this.subscriptions[bot_id]) return;
             const { subscription } = await api_base.api.send({ bot_notification: 1, bot_id, subscribe: 1 });
 
             this.subscriptions = {
@@ -565,6 +566,10 @@ export default class ServerBotStore {
                 msg: bot_remove.message || localize('Bot deleted successfully'),
                 bot_id,
             });
+
+            const subscriptions = { ...this.subscriptions };
+            delete subscriptions[bot_id];
+            this.subscriptions = subscriptions;
         } catch (error) {
             // eslint-disable-next-line no-console
             console.dir(error);


### PR DESCRIPTION
## Changes:
1. If the server bot is open in multiple tabs or multiple browsers, then the bot should run/stop if done in one browser or tab -- it will happen as soon as the tab/browser is in focus

Dev Note:
1. If a bot is deleted then remove the subscription
