### PR TITLE
Niloofar/ Fixed "cfd-compare-accounts" route typo

### DIFF
--- a/packages/shared/src/utils/routes/routes.ts
+++ b/packages/shared/src/utils/routes/routes.ts
@@ -81,7 +81,7 @@ export const routes = {
     old_traders_hub: '/appstore/traders-hub',
     traders_hub: '/',
     onboarding: '/onboarding',
-    compare_cfds: '/cfd-compare-acccounts',
+    compare_cfds: '/cfd-compare-accounts',
 
     // Wallets
     wallets: '/wallet',


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
Fixed spelling error in the URL redirecting to the "Compare CFDs demo accounts" page (https://app.deriv.com/cfd-compare-acccounts).
