### PR TITLE
[WALL] Lubega / ATM amount input default locale

### DIFF
--- a/packages/wallets/src/components/Base/ATMAmountInput/ATMAmountInput.tsx
+++ b/packages/wallets/src/components/Base/ATMAmountInput/ATMAmountInput.tsx
@@ -41,6 +41,7 @@ const WalletTransferFormInputField: React.FC<TProps> = ({
         value: formattedValue,
     } = useInputATMFormatter(inputRef, value, {
         fractionDigits,
+        locale: 'en-US',
         maxDigits,
     });
 


### PR DESCRIPTION
## Changes:

- [x] Added default locale of `en-US` to ATM amount input to resolve input issues when user's system language has a locale with different number formatting

### Bug:


https://github.com/user-attachments/assets/7133c7dd-1e0c-4ca4-8df1-e6355d2342af

### Fix:


https://github.com/user-attachments/assets/60b89bb6-3e24-4b9f-a8fe-2debf1e4639d

