### PR TITLE
[WALL] Lubega / WALL-4938 / Responsive transfer menu overlap

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAccountSelection/TransferFormAccountSelection.scss
+++ b/packages/wallets/src/features/cashier/modules/Transfer/components/TransferFormAccountSelection/TransferFormAccountSelection.scss
@@ -8,7 +8,7 @@
     /* Shadows/xxxl */
     box-shadow: 0rem 3.2rem 6.4rem 0rem rgba(14, 14, 14, 0.14);
     max-height: 52.8rem;
-    z-index: 9999;
+    z-index: 10;
 
     @include mobile-or-tablet-screen {
         position: absolute;


### PR DESCRIPTION
## Changes:

- [x] Reduced z-index of transfer to fix position of modal popup

### Bug:

https://github.com/user-attachments/assets/361afcbe-34c0-4516-b290-037dcb1d9a26

### Fix:


https://github.com/user-attachments/assets/48132658-8360-4e47-9a26-f39db1d298aa

