### PR TITLE
[BOT] Farabi/bot-2235/chart-feed-values-not-showing-on-mobile 

### DIFF
--- a/packages/bot-web-ui/src/pages/chart/chart.scss
+++ b/packages/bot-web-ui/src/pages/chart/chart.scss
@@ -24,8 +24,6 @@
                     display: none;
                 }
                 @include mobile-screen {
-                    min-width: 17rem;
-                    max-width: 26rem;
                     width: auto;
 
                     .cq-menu-btn {
@@ -39,10 +37,7 @@
                             margin-left: auto;
                         }
                         .cq-symbol {
-                            font-size: 1.2rem;
-                        }
-                        .cq-chart-price {
-                            display: none;
+                            font-size: 1.4rem;
                         }
                     }
                 }


### PR DESCRIPTION
## Changes:

- Make chart tab dropdown feed values visible for mobile devices

### Screenshots:

<img width="373" alt="Screenshot 2024-10-07 at 4 18 26 PM" src="https://github.com/user-attachments/assets/dd2db434-af9a-45fe-af93-2aa2419209b0">

