### PR TITLE
[UPM-1349] Suisin/fix: make verification link expired modal to be not closable

### DIFF
--- a/packages/account/src/Sections/Profile/PhoneVerification/verification-link-expired-modal.tsx
+++ b/packages/account/src/Sections/Profile/PhoneVerification/verification-link-expired-modal.tsx
@@ -63,8 +63,10 @@ const VerificationLinkExpiredModal = observer(
                 isOpened={should_show_verification_link_expired_modal}
                 isPrimaryButtonDisabled={!!next_email_otp_request_timer || is_email_otp_timer_loading}
                 buttonColor='coral'
+                showCrossIcon={false}
+                showHandleBar={false}
+                disableCloseOnOverlay
                 isNonExpandable
-                shouldCloseModalOnSwipeDown
                 primaryButtonCallback={handleSendNewLinkButton}
                 primaryButtonLabel={
                     <Localize


### PR DESCRIPTION
## Changes:

make verification link expired modal to be not closable

### Screenshots:


![Screenshot 2024-10-07 at 5 29 26 PM](https://github.com/user-attachments/assets/13c3801e-9187-45f4-992d-fecdc4e91a7f)
![Screenshot 2024-10-07 at 5 29 57 PM](https://github.com/user-attachments/assets/1d62d76a-c5f3-4796-824b-2e8e9b766e25)
