### PR TITLE
[WALL] george /  WALL-4541 / For lifetime transfer limit errors, it displays a cumulative transfer error message.

### DIFF
--- a/packages/wallets/src/components/Base/WalletAlertMessage/WalletAlertMessage.scss
+++ b/packages/wallets/src/components/Base/WalletAlertMessage/WalletAlertMessage.scss
@@ -24,6 +24,12 @@
             display: flex;
             position: relative;
             margin-top: 0.8rem;
+
+            &--info {
+                rect {
+                    fill: var(--status-light-information, #377cfc);
+                }
+            }
         }
     }
 

--- a/packages/wallets/src/components/Base/WalletAlertMessage/WalletAlertMessage.tsx
+++ b/packages/wallets/src/components/Base/WalletAlertMessage/WalletAlertMessage.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react';
+import classNames from 'classnames';
 import { LegacyLossIcon, LegacySettlementFillIcon, LegacyWarningIcon, LegacyWonIcon } from '@deriv/quill-icons';
 import { Text } from '@deriv-com/ui';
 import './WalletAlertMessage.scss';
@@ -41,7 +42,13 @@ const WalletAlertMessage: React.FC<TProps> = ({ children, message, type }) => {
         <div className='wallets-alert-message' data-testid='dt_wallet-alert-message'>
             <div className='wallets-alert-message__icon-container'>
                 <div className='wallets-alert-message__icon-container__line' />
-                <Icon className='wallets-alert-message__icon-container__icon' fill={fill} iconSize='xs' />
+                <Icon
+                    className={classNames('wallets-alert-message__icon-container__icon', {
+                        'wallets-alert-message__icon-container__icon--info': type === 'info',
+                    })}
+                    fill={fill}
+                    iconSize='xs'
+                />
             </div>
             <div className='wallets-alert-message__message-container'>
                 <Text align='start' color={color} size='xs'>

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/__tests__/lifetimeAccountLimitsBetweenWalletsMessageFn.spec.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/__tests__/lifetimeAccountLimitsBetweenWalletsMessageFn.spec.tsx
@@ -309,6 +309,121 @@ describe('lifetimeAccountLimitsBetweenWalletsMessageFn', () => {
         });
     });
 
+    it('handles lifetime limit for fiat transfers when source amount greater than available sum', () => {
+        const resultCryptoToFiat = lifetimeAccountLimitsBetweenWalletsMessageFn({
+            // @ts-expect-error - since this is a mock, we only need partial properties of the hook
+            activeWallet: { currency: 'BTC' },
+            activeWalletExchangeRates: { rates: { BTC: 1, USD: 60000 } },
+            displayMoney: mockDisplayMoney,
+            limits: {
+                lifetime_transfers: {
+                    crypto_to_fiat: {
+                        allowed: 10,
+                        available: 5,
+                    },
+                },
+            },
+            // @ts-expect-error - since this is a mock, we only need partial properties of the hook
+            sourceAccount: cryptoAccount,
+            sourceAmount: 15,
+            // @ts-expect-error - since this is a mock, we only need partial properties of the hook
+            targetAccount: fiatAccount,
+        });
+        expect(resultCryptoToFiat).toEqual({
+            action: {
+                buttonLabel: <Localize i18n_default_text='Verify' />,
+                navigateTo: '/account/proof-of-identity',
+                shouldOpenInNewTab: true,
+            },
+            message: (
+                <Localize
+                    i18n_default_text='The lifetime transfer limit is up to {{formattedSourceCurrencyRemainder}} ({{formattedConvertedSourceCurrencyRemainder}}). Verify your account to upgrade the limit.'
+                    values={{
+                        formattedConvertedSourceCurrencyRemainder: '300000.00 USD',
+                        formattedSourceCurrencyRemainder: '5.00000000 BTC',
+                    }}
+                />
+            ),
+            type: 'error',
+        });
+
+        const resultFiatToCrypto = lifetimeAccountLimitsBetweenWalletsMessageFn({
+            // @ts-expect-error - since this is a mock, we only need partial properties of the hook
+            activeWallet: { currency: 'USD' },
+            activeWalletExchangeRates: { rates: { BTC: 0.00002, USD: 1 } },
+            displayMoney: mockDisplayMoney,
+            limits: {
+                lifetime_transfers: {
+                    fiat_to_crypto: {
+                        allowed: 10000,
+                        available: 5000,
+                    },
+                },
+            },
+            // @ts-expect-error - since this is a mock, we only need partial properties of the hook
+            sourceAccount: fiatAccount,
+            sourceAmount: 7000,
+            // @ts-expect-error - since this is a mock, we only need partial properties of the hook
+            targetAccount: cryptoAccount,
+        });
+        expect(resultFiatToCrypto).toEqual({
+            action: {
+                buttonLabel: <Localize i18n_default_text='Verify' />,
+                navigateTo: '/account/proof-of-identity',
+                shouldOpenInNewTab: true,
+            },
+            message: (
+                <Localize
+                    i18n_default_text='The lifetime transfer limit is up to {{formattedSourceCurrencyRemainder}} ({{formattedConvertedSourceCurrencyRemainder}}). Verify your account to upgrade the limit.'
+                    values={{
+                        formattedConvertedSourceCurrencyRemainder: '0.10000000 BTC',
+                        formattedSourceCurrencyRemainder: '5000.00 USD',
+                    }}
+                />
+            ),
+            type: 'error',
+        });
+    });
+
+    it('handles lifetime limit for crypto to crypto transfers when source amount greater than available sum', () => {
+        const result = lifetimeAccountLimitsBetweenWalletsMessageFn({
+            // @ts-expect-error - since this is a mock, we only need partial properties of the hook
+            activeWallet: { currency: 'BTC' },
+            activeWalletExchangeRates: { rates: { BTC: 1, USD: 60000 } },
+            displayMoney: mockDisplayMoney,
+            limits: {
+                lifetime_transfers: {
+                    crypto_to_crypto: {
+                        allowed: 10,
+                        available: 5,
+                    },
+                },
+            },
+            // @ts-expect-error - since this is a mock, we only need partial properties of the hook
+            sourceAccount: cryptoAccount,
+            sourceAmount: 15,
+            // @ts-expect-error - since this is a mock, we only need partial properties of the hook
+            targetAccount: cryptoAccount,
+        });
+        expect(result).toEqual({
+            action: {
+                buttonLabel: <Localize i18n_default_text='Verify' />,
+                navigateTo: '/account/proof-of-identity',
+                shouldOpenInNewTab: true,
+            },
+            message: (
+                <Localize
+                    i18n_default_text='The lifetime transfer limit is up to {{formattedSourceCurrencyRemainder}} ({{formattedSourceCurrencyReminderInUSD}}). Verify your account to upgrade the limit.'
+                    values={{
+                        formattedSourceCurrencyRemainder: '5.00000000 BTC',
+                        formattedSourceCurrencyReminderInUSD: '300000.00 USD',
+                    }}
+                />
+            ),
+            type: 'error',
+        });
+    });
+
     it('returns null if sourceAccount currency does not match activeWallet currency and no exchange rate', () => {
         const result = lifetimeAccountLimitsBetweenWalletsMessageFn({
             // @ts-expect-error - since this is a mock, we only need partial properties of the hook


### PR DESCRIPTION
## Changes:

- If the user attempts to transfer an amount greater than the lifetime transfer limit, they should not be allowed to proceed. The transfer button should be disabled, and an error message related to the lifetime transfer limit should be displayed within the transfer form.
- Fix info icon color

### Screenshots:

![Screenshot 2024-10-07 at 16 01 32](https://github.com/user-attachments/assets/1c95979d-92bd-4684-ab4f-290e4627660c)
![Screenshot 2024-10-07 at 16 01 53](https://github.com/user-attachments/assets/0cfe7731-b3ff-4d79-b55e-be54d3f7dbf0)
![Screenshot 2024-10-07 at 16 02 02](https://github.com/user-attachments/assets/8558e4a8-c39e-4dc6-a5d1-131400baceef)

