### PR TITLE
[WALL] WALL-4761 / george / The Resend Email CTA is not clickable on the expired withdrawal verification page

### DIFF
--- a/packages/wallets/src/features/cashier/flows/WalletWithdrawal/WalletWithdrawal.tsx
+++ b/packages/wallets/src/features/cashier/flows/WalletWithdrawal/WalletWithdrawal.tsx
@@ -59,7 +59,11 @@ const WalletWithdrawal = () => {
                 verificationCode={verificationCode}
             />
         ) : (
-            <WithdrawalFiatModule verificationCode={verificationCode} />
+            <WithdrawalFiatModule
+                setResendEmail={setResendEmail}
+                setVerificationCode={setVerificationCode}
+                verificationCode={verificationCode}
+            />
         );
     }
 

--- a/packages/wallets/src/features/cashier/modules/WithdrawalFiat/__tests__/WithdrawalFiat.spec.tsx
+++ b/packages/wallets/src/features/cashier/modules/WithdrawalFiat/__tests__/WithdrawalFiat.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useCashierFiatAddress } from '@deriv/api-v2';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import WithdrawalFiat from '../WithdrawalFiat';
 
 jest.mock('@deriv/api-v2', () => ({
@@ -28,20 +28,37 @@ describe('<WithdrawalFiat />', () => {
             mutateAsync: jest.fn().mockResolvedValueOnce({}),
         });
 
-        render(<WithdrawalFiat verificationCode={verificationCode} />);
+        render(
+            <WithdrawalFiat
+                setResendEmail={jest.fn()}
+                setVerificationCode={jest.fn()}
+                verificationCode={verificationCode}
+            />
+        );
 
         expect(screen.getByText('Loading...')).toBeInTheDocument();
     });
 
-    it('should render error screen for fiat withdrawal error', () => {
+    it('should render error screen for fiat withdrawal error', async () => {
         (useCashierFiatAddress as jest.Mock).mockReturnValue({
-            error: { error: { code: 'CashierForwardError', message: 'Fiat Error' } },
-            mutateAsync: jest.fn().mockResolvedValueOnce({}),
+            data: 'https://iframe_url',
+            isLoading: false,
+            mutateAsync: jest
+                .fn()
+                .mockRejectedValueOnce({ error: { code: 'CashierForwardError', message: 'Fiat Error' } }),
         });
 
-        render(<WithdrawalFiat verificationCode={verificationCode} />);
+        render(
+            <WithdrawalFiat
+                setResendEmail={jest.fn()}
+                setVerificationCode={jest.fn()}
+                verificationCode={verificationCode}
+            />
+        );
 
-        expect(screen.getByText(/MockedWithdrawalErrorScreen - Fiat Error/)).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText(/MockedWithdrawalErrorScreen - Fiat Error/)).toBeInTheDocument();
+        });
     });
 
     it('should render the loader while the iframe is loading', () => {
@@ -50,7 +67,13 @@ describe('<WithdrawalFiat />', () => {
             mutateAsync: jest.fn().mockResolvedValueOnce({}),
         });
 
-        render(<WithdrawalFiat verificationCode={verificationCode} />);
+        render(
+            <WithdrawalFiat
+                setResendEmail={jest.fn()}
+                setVerificationCode={jest.fn()}
+                verificationCode={verificationCode}
+            />
+        );
 
         expect(screen.getByText('Loading...')).toBeInTheDocument();
     });
@@ -62,7 +85,13 @@ describe('<WithdrawalFiat />', () => {
             mutateAsync: jest.fn().mockResolvedValueOnce({}),
         });
 
-        render(<WithdrawalFiat verificationCode={verificationCode} />);
+        render(
+            <WithdrawalFiat
+                setResendEmail={jest.fn()}
+                setVerificationCode={jest.fn()}
+                verificationCode={verificationCode}
+            />
+        );
         const iframe = screen.getByTestId('dt_wallets_withdrawal_fiat_iframe');
         expect(iframe).toHaveAttribute('src', 'https://iframe_url');
         expect(iframe).toHaveStyle({ display: 'none' });


### PR DESCRIPTION
## Changes:

- fix the Resend Email CTA is not clickable on the expired withdrawal verification page for fiat withdrawal

### Screenshots:

Please provide some screenshots of the change.

https://github.com/user-attachments/assets/8f53db24-8242-4800-9fa1-6173b09c009e

