### PR TITLE
[BOT] Farabi/bot-2301/open-accumulator-video-directly

### DIFF
--- a/packages/bot-web-ui/src/pages/dashboard/announcements/__tests__/announcement-dialog.spec.tsx
+++ b/packages/bot-web-ui/src/pages/dashboard/announcements/__tests__/announcement-dialog.spec.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { mockStore, StoreProvider } from '@deriv/stores';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { mock_ws } from 'Utils/mock';
 import RootStore from 'Stores/index';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
-import userEvent from '@testing-library/user-event';
 import AnnouncementDialog from '../announcement-dialog';
 import { ANNOUNCEMENTS } from '../config';
 

--- a/packages/bot-web-ui/src/pages/dashboard/announcements/__tests__/announcement.spec.tsx
+++ b/packages/bot-web-ui/src/pages/dashboard/announcements/__tests__/announcement.spec.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { mockStore, StoreProvider } from '@deriv/stores';
+import { Notifications as Announcement } from '@deriv-com/ui';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { mock_ws } from 'Utils/mock';
 import RootStore from 'Stores/index';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
-import { Notifications as Announcement } from '@deriv-com/ui';
-import userEvent from '@testing-library/user-event';
 
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());
 

--- a/packages/bot-web-ui/src/pages/dashboard/announcements/__tests__/announcements.spec.tsx
+++ b/packages/bot-web-ui/src/pages/dashboard/announcements/__tests__/announcements.spec.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { mockStore, StoreProvider } from '@deriv/stores';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DBOT_TABS } from 'Constants/bot-contents';
 import { mock_ws } from 'Utils/mock';
 import RootStore from 'Stores/index';
 import { DBotStoreProvider, mockDBotStore } from 'Stores/useDBotStore';
 import Announcements from '../announcements';
-import userEvent from '@testing-library/user-event';
-import { DBOT_TABS } from 'Constants/bot-contents';
 import { BOT_ANNOUNCEMENTS_LIST } from '../config';
 
 jest.mock('@deriv/bot-skeleton/src/scratch/dbot', () => jest.fn());

--- a/packages/bot-web-ui/src/pages/dashboard/announcements/announcement-dialog.tsx
+++ b/packages/bot-web-ui/src/pages/dashboard/announcements/announcement-dialog.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Dialog, Text } from '@deriv/components';
 import { LabelPairedCheckCaptionFillIcon } from '@deriv/quill-icons';
-import './announcement-dialog.scss';
-import { TAnnounce, TContentItem } from './config';
 import { IconAnnounceModal } from './announcement-components';
+import { TAnnounce, TContentItem } from './config';
+import './announcement-dialog.scss';
 
 type TAccumulatorAnnouncementDialog = {
     announcement: TAnnounce;

--- a/packages/bot-web-ui/src/pages/dashboard/announcements/announcements.tsx
+++ b/packages/bot-web-ui/src/pages/dashboard/announcements/announcements.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
-import { observer } from '@deriv/stores';
-import { Text } from '@deriv/components';
-import { Notifications as Announcement } from '@deriv-com/ui';
-import { StandaloneBullhornRegularIcon } from '@deriv/quill-icons';
-import { useHistory } from 'react-router-dom';
 import classNames from 'classnames';
+import { useHistory } from 'react-router-dom';
+import { Text } from '@deriv/components';
+import { StandaloneBullhornRegularIcon } from '@deriv/quill-icons';
+import { observer } from '@deriv/stores';
 import { localize } from '@deriv/translations';
+import { Notifications as Announcement } from '@deriv-com/ui';
+import { useDBotStore } from 'Stores/useDBotStore';
+import { guide_content } from '../../tutorials/constants';
+import { performButtonAction } from './utils/accumulator-helper-functions';
+import { MessageAnnounce, TitleAnnounce } from './announcement-components';
 import AnnouncementDialog from './announcement-dialog';
 import { BOT_ANNOUNCEMENTS_LIST, TAnnouncement, TNotifications } from './config';
 import './announcements.scss';
-import { MessageAnnounce, TitleAnnounce } from './announcement-components';
-import { performButtonAction } from './utils/accumulator-helper-functions';
-import { useDBotStore } from 'Stores/useDBotStore';
 
 type TAnnouncements = {
     is_mobile?: boolean;
@@ -22,6 +23,7 @@ type TAnnouncements = {
 const Announcements = observer(({ is_mobile, is_tablet, handleTabChange }: TAnnouncements) => {
     const {
         load_modal: { toggleLoadModal },
+        dashboard: { showVideoDialog },
     } = useDBotStore();
     const [is_announce_dialog_open, setIsAnnounceDialogOpen] = React.useState(false);
     const [is_open_announce_list, setIsOpenAnnounceList] = React.useState(false);
@@ -92,9 +94,19 @@ const Announcements = observer(({ is_mobile, is_tablet, handleTabChange }: TAnno
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [read_announcements_map]);
 
+    const openAccumulatorsVideo = () => {
+        const accumulator_video = guide_content.find(guide_content => guide_content.id === 4);
+        if (accumulator_video) {
+            showVideoDialog({ url: accumulator_video.url, type: 'url' });
+        }
+    };
+
     const handleOnCancel = () => {
         if (selected_announcement?.switch_tab_on_cancel) {
             handleTabChange(selected_announcement.switch_tab_on_cancel);
+            if (selected_announcement.announcement.id === 'ACCUMULATOR_ANNOUNCE') {
+                openAccumulatorsVideo();
+            }
         }
         selected_announcement?.onCancel?.();
         setSelectedAnnouncement(null);

--- a/packages/bot-web-ui/src/pages/dashboard/announcements/announcements.tsx
+++ b/packages/bot-web-ui/src/pages/dashboard/announcements/announcements.tsx
@@ -95,9 +95,9 @@ const Announcements = observer(({ is_mobile, is_tablet, handleTabChange }: TAnno
     }, [read_announcements_map]);
 
     const openAccumulatorsVideo = () => {
-        const accumulator_video = guide_content.find(guide_content => guide_content.id === 4);
-        if (accumulator_video) {
-            showVideoDialog({ url: accumulator_video.url, type: 'url' });
+        const accumulators_video = guide_content.find(guide_content => guide_content.id === 4);
+        if (accumulators_video) {
+            showVideoDialog({ url: accumulators_video.url, type: 'url' });
         }
     };
 

--- a/packages/bot-web-ui/src/pages/dashboard/announcements/config.tsx
+++ b/packages/bot-web-ui/src/pages/dashboard/announcements/config.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
+import { OpenLiveChatLink } from '@deriv/components';
 import { Localize, localize } from '@deriv/translations';
 import { DBOT_TABS } from 'Constants/bot-contents';
 import { handleOnConfirmAccumulator } from './utils/accumulator-helper-functions';
 import { IconAnnounce } from './announcement-components';
-import { OpenLiveChatLink } from '@deriv/components';
 
 export type TContentItem = {
     id: number;
@@ -144,7 +144,7 @@ export const ANNOUNCEMENTS: Record<string, TAnnouncement> = {
         },
         switch_tab_on_cancel: DBOT_TABS.TUTORIAL,
         switch_tab_on_confirm: DBOT_TABS.BOT_BUILDER,
-        onConfirm: handleOnConfirmAccumulator,
+        onConfirm: () => handleOnConfirmAccumulator(),
     },
 };
 


### PR DESCRIPTION
## Changes:

- Open accumulators video directly in tutorials when clicking on learn more from the announcements from dashboard

### Screenshots:

https://github.com/user-attachments/assets/caa79da2-31fe-477e-bdd9-8d3f061a4e74

