### PR TITLE
[DTRA]Ahmad/DTRA-1963/Trade Type Redirection Issue on Options Page

### DIFF
--- a/packages/shared/src/utils/contract/trade-url-params-config.ts
+++ b/packages/shared/src/utils/contract/trade-url-params-config.ts
@@ -68,7 +68,10 @@ export const getTradeURLParams = ({ active_symbols = [], contract_types_list = {
                 contract_types_list[key]?.categories || [];
             return [...acc, ...categories.map(contract => (contract as TTextValueStrings).value)];
         }, []);
-        const isTradeTypeValid = contractList.includes(trade_type ?? '');
+
+        const isTradeTypeValid =
+            (contractList.length === 0 && trade_type !== '') ||
+            (contractList.length > 0 && contractList.includes(trade_type ?? ''));
 
         if (validInterval) result.granularity = Number(validInterval.value);
         if (validChartType) result.chartType = chartTypeParam;

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.ts
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.ts
@@ -1801,7 +1801,7 @@ export default class TradeStore extends BaseStore {
     }
 
     setChartModeFromURL() {
-        const { chartType: chartTypeParam, granularity: granularityParam } = getTradeURLParams();
+        const { chartType: chartTypeParam, granularity: granularityParam, contractType } = getTradeURLParams();
         const { chart_type, granularity, updateChartType, updateGranularity } = this.root_store.contract_trade;
         if (!isNaN(Number(granularityParam)) && granularityParam !== granularity) {
             updateGranularity(Number(granularityParam));
@@ -1809,9 +1809,13 @@ export default class TradeStore extends BaseStore {
         if (chartTypeParam && chartTypeParam !== chart_type) {
             updateChartType(chartTypeParam);
         }
+
+        this.contract_type = contractType ?? '';
+
         setTradeURLParams({
             chartType: chartTypeParam ?? chart_type,
             granularity: granularityParam ?? Number(granularity),
+            contractType: contractType ?? '',
         });
     }
 


### PR DESCRIPTION
Previously, when selecting any trade type on the Options page, the page would automatically redirect and open the Accumulators trade type, regardless of the user's selection. This issue caused confusion as users expected the selected trade type to open.

This issue has now been resolved. When a user selects a trade type, the page correctly opens the respective trade type as chosen by the user. The redirection behavior has been fixed to reflect the correct trade type selection, ensuring a more intuitive and user-friendly experience.

