### PR TITLE
Display Trustpilot Review Notification Based on Backend Status

### DIFF
--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -170,6 +170,8 @@ export default class ClientStore extends BaseStore {
     subscriptions = {};
     exchange_rates = {};
 
+    should_show_trustpilot_notification = false;
+
     constructor(root_store) {
         const local_storage_properties = ['device_data'];
         super({ root_store, local_storage_properties, store_name });
@@ -247,6 +249,7 @@ export default class ClientStore extends BaseStore {
             is_phone_number_verification_enabled: observable,
             passkeys_list: observable,
             should_show_passkey_notification: observable,
+            should_show_trustpilot_notification: observable,
             balance: computed,
             account_open_date: computed,
             is_svg: computed,
@@ -2928,5 +2931,9 @@ export default class ClientStore extends BaseStore {
 
     get is_account_to_be_closed_by_residence() {
         return this.account_time_of_closure && this.residence && this.residence === 'sn';
+    }
+
+    get should_show_trustpilot_notification() {
+        return this.account_status?.status?.includes('customer_review_eligible');
     }
 }

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -170,8 +170,6 @@ export default class ClientStore extends BaseStore {
     subscriptions = {};
     exchange_rates = {};
 
-    should_show_trustpilot_notification = false;
-
     constructor(root_store) {
         const local_storage_properties = ['device_data'];
         super({ root_store, local_storage_properties, store_name });
@@ -249,7 +247,6 @@ export default class ClientStore extends BaseStore {
             is_phone_number_verification_enabled: observable,
             passkeys_list: observable,
             should_show_passkey_notification: observable,
-            should_show_trustpilot_notification: observable,
             balance: computed,
             account_open_date: computed,
             is_svg: computed,
@@ -436,6 +433,7 @@ export default class ClientStore extends BaseStore {
             setTradersHubTracking: action.bound,
             account_time_of_closure: computed,
             is_account_to_be_closed_by_residence: computed,
+            should_show_trustpilot_notification: computed,
         });
 
         reaction(

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -4,7 +4,6 @@ import { action, computed, makeObservable, observable, reaction } from 'mobx';
 import { StaticUrl } from '@deriv/components';
 import {
     checkServerMaintenance,
-    // daysSince,
     extractInfoFromShortcode,
     formatDate,
     formatMoney,
@@ -315,7 +314,6 @@ export default class NotificationStore extends BaseStore {
             account_list,
             account_settings,
             account_status,
-            // account_open_date,
             accounts,
             isAccountOfType,
             is_eu,
@@ -346,10 +344,9 @@ export default class NotificationStore extends BaseStore {
         const { current_language, selected_contract_type } = this.root_store.common;
         const malta_account = landing_company_shortcode === 'maltainvest';
         const cr_account = landing_company_shortcode === 'svg';
-        // const is_website_up = website_status.site_status === 'up';
-        // const has_trustpilot = LocalStore.getObject('notification_messages')[loginid]?.includes(
-        //     this.client_notifications.trustpilot?.key
-        // );
+        const has_trustpilot = LocalStore.getObject('marked_notifications').includes(
+            this.client_notifications.trustpilot?.key
+        );
         const is_next_email_attempt_timer_running = shouldShowPhoneVerificationNotification(
             account_settings?.phone_number_verification?.next_email_attempt,
             current_time
@@ -457,7 +454,7 @@ export default class NotificationStore extends BaseStore {
                 });
             }
 
-            if (this.root_store.client.should_show_trustpilot_notification) {
+            if (!has_trustpilot && this.root_store.client.should_show_trustpilot_notification) {
                 this.addNotificationMessage(this.client_notifications.trustpilot);
             }
 
@@ -627,9 +624,6 @@ export default class NotificationStore extends BaseStore {
                 } else {
                     this.removeNotificationMessageByKey({ key: this.client_notifications.dp2p?.key });
                 }
-                // if (is_website_up && !has_trustpilot && daysSince(account_open_date) > 7) {
-                //     this.addNotificationMessage(this.client_notifications.trustpilot);
-                // }
                 has_missing_required_field = hasMissingRequiredField(account_settings, client, isAccountOfType);
                 if (has_missing_required_field) {
                     this.addNotificationMessage(
@@ -842,7 +836,7 @@ export default class NotificationStore extends BaseStore {
                 action: {
                     onClick: () => {
                         window.open('https://www.trustpilot.com/evaluate/deriv.com', '_blank');
-                        this.removeNotificationByKey({ key: this.client_notifications.trustpilot.key });
+                        this.markNotificationMessage({ key: this.client_notifications.trustpilot.key });
                         this.removeNotificationMessage({
                             key: this.client_notifications.trustpilot.key,
                             should_show_again: false,

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -837,10 +837,6 @@ export default class NotificationStore extends BaseStore {
                     onClick: () => {
                         window.open('https://www.trustpilot.com/evaluate/deriv.com', '_blank');
                         this.markNotificationMessage({ key: this.client_notifications.trustpilot.key });
-                        this.removeNotificationMessage({
-                            key: this.client_notifications.trustpilot.key,
-                            should_show_again: false,
-                        });
                     },
                     text: localize('Go to Trustpilot'),
                 },
@@ -848,6 +844,7 @@ export default class NotificationStore extends BaseStore {
                 img_alt: 'Trustpilot',
                 className: 'trustpilot',
                 type: 'trustpilot',
+                should_show_again: false,
             },
             currency: {
                 key: 'currency',

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -4,7 +4,7 @@ import { action, computed, makeObservable, observable, reaction } from 'mobx';
 import { StaticUrl } from '@deriv/components';
 import {
     checkServerMaintenance,
-    daysSince,
+    // daysSince,
     extractInfoFromShortcode,
     formatDate,
     formatMoney,
@@ -315,7 +315,7 @@ export default class NotificationStore extends BaseStore {
             account_list,
             account_settings,
             account_status,
-            account_open_date,
+            // account_open_date,
             accounts,
             isAccountOfType,
             is_eu,
@@ -346,10 +346,10 @@ export default class NotificationStore extends BaseStore {
         const { current_language, selected_contract_type } = this.root_store.common;
         const malta_account = landing_company_shortcode === 'maltainvest';
         const cr_account = landing_company_shortcode === 'svg';
-        const is_website_up = website_status.site_status === 'up';
-        const has_trustpilot = LocalStore.getObject('notification_messages')[loginid]?.includes(
-            this.client_notifications.trustpilot?.key
-        );
+        // const is_website_up = website_status.site_status === 'up';
+        // const has_trustpilot = LocalStore.getObject('notification_messages')[loginid]?.includes(
+        //     this.client_notifications.trustpilot?.key
+        // );
         const is_next_email_attempt_timer_running = shouldShowPhoneVerificationNotification(
             account_settings?.phone_number_verification?.next_email_attempt,
             current_time
@@ -455,6 +455,10 @@ export default class NotificationStore extends BaseStore {
                 this.removeNotificationByKey({
                     key: this.client_notifications.notify_account_is_to_be_closed_by_residence,
                 });
+            }
+
+            if (this.root_store.client.should_show_trustpilot_notification) {
+                this.addNotificationMessage(this.client_notifications.trustpilot);
             }
 
             const client = accounts[loginid];
@@ -623,9 +627,9 @@ export default class NotificationStore extends BaseStore {
                 } else {
                     this.removeNotificationMessageByKey({ key: this.client_notifications.dp2p?.key });
                 }
-                if (is_website_up && !has_trustpilot && daysSince(account_open_date) > 7) {
-                    this.addNotificationMessage(this.client_notifications.trustpilot);
-                }
+                // if (is_website_up && !has_trustpilot && daysSince(account_open_date) > 7) {
+                //     this.addNotificationMessage(this.client_notifications.trustpilot);
+                // }
                 has_missing_required_field = hasMissingRequiredField(account_settings, client, isAccountOfType);
                 if (has_missing_required_field) {
                     this.addNotificationMessage(

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -837,6 +837,13 @@ export default class NotificationStore extends BaseStore {
                     onClick: () => {
                         window.open('https://www.trustpilot.com/evaluate/deriv.com', '_blank');
                         this.markNotificationMessage({ key: this.client_notifications.trustpilot.key });
+                        this.removeNotificationByKey({
+                            key: this.client_notifications.trustpilot.key,
+                        });
+                        this.removeNotificationMessage({
+                            key: this.client_notifications.trustpilot.key,
+                            should_show_again: false,
+                        });
                     },
                     text: localize('Go to Trustpilot'),
                 },

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -851,7 +851,6 @@ export default class NotificationStore extends BaseStore {
                 img_alt: 'Trustpilot',
                 className: 'trustpilot',
                 type: 'trustpilot',
-                should_show_again: false,
             },
             currency: {
                 key: 'currency',

--- a/packages/stores/src/mockStore.ts
+++ b/packages/stores/src/mockStore.ts
@@ -318,6 +318,7 @@ const mock = (): TStores & { is_mock: boolean } => {
             setTradersHubTracking: jest.fn(),
             account_time_of_closure: undefined,
             is_account_to_be_closed_by_residence: false,
+            should_show_trustpilot_notification: false,
         },
         common: {
             error: common_store_error,

--- a/packages/stores/types.ts
+++ b/packages/stores/types.ts
@@ -643,6 +643,7 @@ export type TClientStore = {
     setTradersHubTracking: (value: boolean) => void;
     account_time_of_closure?: number;
     is_account_to_be_closed_by_residence: boolean;
+    should_show_trustpilot_notification: boolean;
 };
 
 type TCommonStoreError = {


### PR DESCRIPTION
## Changes:

Display Trustpilot Review Notification based on `customer_review_eligible` status received in `get_account_status` API. This PR removes the existing business logic for displaying trustpilot notification.

### Screenshots:

Please provide some screenshots of the change.
