### PR TITLE
[TRAH] shontzu/TRAH-4286/Remove-Trading-accounts-and-funds-section-in-terms-of-use-screen

### DIFF
--- a/packages/account/src/Components/terms-of-use/terms-of-use-messages.tsx
+++ b/packages/account/src/Components/terms-of-use/terms-of-use-messages.tsx
@@ -50,17 +50,6 @@ export const BrokerSpecificMessage = ({ target }: { target: TBrokerCodes }) => {
             <Text as='p' size={isDesktop ? 'xs' : 'xxs'}>
                 <Localize i18n_default_text='The financial trading services offered on this site are only suitable for customers who accept the possibility of losing all the money they invest and who understand and have experience of the risk involved in the purchase of financial contracts. Transactions in financial contracts carry a high degree of risk. If the contracts you purchased expire as worthless, you will lose all your investment, which includes the contract premium.' />
             </Text>
-            {target === Jurisdiction.MALTA_INVEST && (
-                <React.Fragment>
-                    <Hr />
-                    <Text as='h4' size='xs' weight='bold'>
-                        <Localize i18n_default_text='Trading accounts and funds' />
-                    </Text>
-                    <Text as='p' size={isDesktop ? 'xs' : 'xxs'}>
-                        <Localize i18n_default_text="You acknowledge that, subject to the Company's discretion, applicable regulations, and internal checks being fulfilled, we will open an account for you and allow you to deposit funds during the client acceptance procedure. However, until the verification of your account is completed, you will not be able to trade, withdraw or make further deposits. If you do not provide relevant documents within 30-days, we will refund the deposited amount through the same payment method you used to deposit." />
-                    </Text>
-                </React.Fragment>
-            )}
         </React.Fragment>
     );
 };


### PR DESCRIPTION
chore: MF tnc content update

## Changes:

In MF, during real account creation, the **Risk warning** section used to have an extra MF-specific content which is now being removed

### Screenshots:

<img width="626" alt="image" src="https://github.com/user-attachments/assets/26327eac-356c-46eb-a3dc-d6aa44b90e65">

