### PR TITLE
Akmal / fix: set default trade type when switching to vanillas and turbos

### DIFF
--- a/packages/trader/src/AppV2/Components/TradeParameters/TradeTypeTabs/trade-type-tabs.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/TradeTypeTabs/trade-type-tabs.tsx
@@ -12,9 +12,20 @@ type TTradeTypeTabsProps = {
 const TradeTypeTabs = observer(({ is_minimized }: TTradeTypeTabsProps) => {
     const { contract_type, onChange, trade_type_tab, setTradeTypeTab } = useTraderStore();
     const tab_list = getTradeTypeTabsList(contract_type);
-    const initial_index = tab_list.findIndex(tab =>
-        trade_type_tab ? tab.contract_type === trade_type_tab : tab.value === contract_type
-    );
+    let initial_index = 0;
+
+    // If the trade type tab is VANILLALONGPUT or TURBOSSHORT, keep the first tab
+    if (
+        !(
+            (trade_type_tab === 'VANILLALONGPUT' && contract_type === 'vanillalongcall') ||
+            (trade_type_tab === 'TURBOSSHORT' && contract_type === 'turboslong')
+        )
+    ) {
+        initial_index = tab_list.findIndex(tab =>
+            trade_type_tab ? tab.contract_type === trade_type_tab : tab.value === contract_type
+        );
+    }
+
     const initial_tab_index = initial_index < 0 ? 0 : initial_index;
     const [tab_index, setTabIndex] = React.useState(initial_tab_index);
 


### PR DESCRIPTION
## Changes:

This fix ensures that a default trade type is set when switching to Vanillas or Turbos, preventing an issue where buttons may disappear due to undefined trade types.

1. Default Trade Type Handling: Automatically set a default trade type when switching to Vanillas or Turbos to avoid issues with missing buttons caused by undefined selections.
2. User Interface Stability: Ensure the interface remains stable and all necessary buttons are visible when changing trade categories.
3. Improved User Experience: Prevent confusion or workflow interruptions by guaranteeing the default trade type is properly initialized, maintaining button visibility.

This fix enhances the user experience by preventing button disappearance when switching between Vanillas and Turbos, ensuring seamless trade configuration.

