### PR TITLE
DTRA-2055 / Kate / [DTrader-V2] Trade page scrolling issue

### DIFF
--- a/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier.tsx
@@ -8,6 +8,7 @@ import Carousel from 'AppV2/Components/Carousel';
 import BarrierDescription from './barrier-description';
 import BarrierInput from './barrier-input';
 import CarouselHeader from 'AppV2/Components/Carousel/carousel-header';
+import { removeFocus } from 'AppV2/Utils/layout-utils';
 
 type TDurationProps = {
     is_minimized?: boolean;
@@ -49,7 +50,10 @@ const Barrier = observer(({ is_minimized }: TDurationProps) => {
                 readOnly
                 label={<Localize i18n_default_text='Barrier' key={`barrier${is_minimized ? '-minimized' : ''}`} />}
                 value={v2_params_initial_values.barrier_1 || barrier_1}
-                onClick={() => setIsOpen(true)}
+                onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+                    removeFocus(e);
+                    setIsOpen(true);
+                }}
                 className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
             />
             <ActionSheet.Root isOpen={is_open} onClose={() => onClose(false)} position='left' expandable={false}>

--- a/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier.tsx
@@ -54,6 +54,7 @@ const Barrier = observer(({ is_minimized }: TDurationProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
+                onMouseDown={removeFocus}
                 className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
             />
             <ActionSheet.Root isOpen={is_open} onClose={() => onClose(false)} position='left' expandable={false}>

--- a/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier.tsx
@@ -54,10 +54,17 @@ const Barrier = observer(({ is_minimized }: TDurationProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
-                onMouseDown={removeFocus}
                 className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
             />
-            <ActionSheet.Root isOpen={is_open} onClose={() => onClose(false)} position='left' expandable={false}>
+            <ActionSheet.Root
+                isOpen={is_open}
+                onClose={() => {
+                    onClose(false);
+                    removeFocus();
+                }}
+                position='left'
+                expandable={false}
+            >
                 <ActionSheet.Portal shouldCloseOnDrag>
                     <Carousel
                         header={CarouselHeader}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
@@ -156,7 +156,6 @@ const DayInput = ({
                     removeFocus(e);
                     setOpen(true);
                 }}
-                onMouseDown={removeFocus}
                 leftIcon={<LabelPairedCalendarSmRegularIcon width={24} height={24} />}
             />
 
@@ -171,7 +170,6 @@ const DayInput = ({
                     removeFocus(e);
                     setOpenTimePicker(true);
                 }}
-                onMouseDown={removeFocus}
                 leftIcon={<LabelPairedClockThreeSmRegularIcon width={24} height={24} />}
             />
 
@@ -189,6 +187,7 @@ const DayInput = ({
                 onClose={() => {
                     setOpen(false);
                     setOpenTimePicker(false);
+                    removeFocus();
                 }}
                 position='left'
                 expandable={false}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
@@ -16,6 +16,7 @@ import {
 } from 'AppV2/Utils/trade-params-utils';
 import { useDtraderQuery } from 'AppV2/Hooks/useDtraderQuery';
 import { ProposalResponse } from 'Stores/Modules/Trading/trade-store';
+import { removeFocus } from 'AppV2/Utils/layout-utils';
 
 const timeToMinutes = (time: string) => {
     const [hours, minutes] = time.split(':').map(Number);
@@ -151,7 +152,8 @@ const DayInput = ({
                 textAlignment='center'
                 value={formatted_date}
                 disabled={duration_units_list.filter(item => item.value === 'd').length === 0}
-                onClick={() => {
+                onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+                    removeFocus(e);
                     setOpen(true);
                 }}
                 leftIcon={<LabelPairedCalendarSmRegularIcon width={24} height={24} />}
@@ -164,7 +166,8 @@ const DayInput = ({
                 name='time'
                 value={`${(formatted_date === formatted_current_date ? end_time : temp_expiry_time) || '23:59:59'} GMT`}
                 disabled={formatted_date !== formatted_current_date || !is_24_hours_contract}
-                onClick={() => {
+                onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+                    removeFocus(e);
                     setOpenTimePicker(true);
                 }}
                 leftIcon={<LabelPairedClockThreeSmRegularIcon width={24} height={24} />}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
@@ -156,6 +156,7 @@ const DayInput = ({
                     removeFocus(e);
                     setOpen(true);
                 }}
+                onMouseDown={removeFocus}
                 leftIcon={<LabelPairedCalendarSmRegularIcon width={24} height={24} />}
             />
 
@@ -170,6 +171,7 @@ const DayInput = ({
                     removeFocus(e);
                     setOpenTimePicker(true);
                 }}
+                onMouseDown={removeFocus}
                 leftIcon={<LabelPairedClockThreeSmRegularIcon width={24} height={24} />}
             />
 

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
@@ -175,6 +175,7 @@ const Duration = observer(({ is_minimized }: TDurationProps) => {
                     removeFocus(e);
                     setOpen(true);
                 }}
+                onMouseDown={removeFocus}
                 status={has_error ? 'error' : 'neutral'}
             />
             <ActionSheet.Root

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
@@ -175,13 +175,13 @@ const Duration = observer(({ is_minimized }: TDurationProps) => {
                     removeFocus(e);
                     setOpen(true);
                 }}
-                onMouseDown={removeFocus}
                 status={has_error ? 'error' : 'neutral'}
             />
             <ActionSheet.Root
                 isOpen={is_open}
                 onClose={() => {
                     setOpen(false);
+                    removeFocus();
                 }}
                 position='left'
                 expandable={false}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
@@ -10,6 +10,7 @@ import { getDisplayedContractTypes } from 'AppV2/Utils/trade-types-utils';
 import useActiveSymbols from 'AppV2/Hooks/useActiveSymbols';
 import { getDatePickerStartDate, getSmallestDuration } from 'AppV2/Utils/trade-params-utils';
 import { useStore } from '@deriv/stores';
+import { removeFocus } from 'AppV2/Utils/layout-utils';
 
 type TDurationProps = {
     is_minimized?: boolean;
@@ -170,7 +171,10 @@ const Duration = observer(({ is_minimized }: TDurationProps) => {
                 noStatusIcon
                 disabled={isMarketClosed(activeSymbols, symbol)}
                 className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
-                onClick={() => setOpen(true)}
+                onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+                    removeFocus(e);
+                    setOpen(true);
+                }}
                 status={has_error ? 'error' : 'neutral'}
             />
             <ActionSheet.Root

--- a/packages/trader/src/AppV2/Components/TradeParameters/GrowthRate/growth-rate.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/GrowthRate/growth-rate.tsx
@@ -103,6 +103,7 @@ const GrowthRate = observer(({ is_minimized }: TGrowthRateProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
+                onMouseDown={removeFocus}
                 readOnly
                 value={`${getGrowthRatePercentage(growth_rate)}%`}
                 variant='fill'

--- a/packages/trader/src/AppV2/Components/TradeParameters/GrowthRate/growth-rate.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/GrowthRate/growth-rate.tsx
@@ -44,6 +44,7 @@ const GrowthRate = observer(({ is_minimized }: TGrowthRateProps) => {
     };
     const onActionSheetClose = () => {
         setIsOpen(false);
+        removeFocus();
     };
 
     const action_sheet_content = [
@@ -103,7 +104,6 @@ const GrowthRate = observer(({ is_minimized }: TGrowthRateProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
-                onMouseDown={removeFocus}
                 readOnly
                 value={`${getGrowthRatePercentage(growth_rate)}%`}
                 variant='fill'

--- a/packages/trader/src/AppV2/Components/TradeParameters/GrowthRate/growth-rate.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/GrowthRate/growth-rate.tsx
@@ -11,6 +11,7 @@ import CarouselHeader from 'AppV2/Components/Carousel/carousel-header';
 import TradeParamDefinition from 'AppV2/Components/TradeParamDefinition';
 import { isSmallScreen } from 'AppV2/Utils/trade-params-utils';
 import GrowthRatePicker from './growth-rate-picker';
+import { removeFocus } from 'AppV2/Utils/layout-utils';
 
 type TGrowthRateProps = {
     is_minimized?: boolean;
@@ -98,7 +99,10 @@ const GrowthRate = observer(({ is_minimized }: TGrowthRateProps) => {
                 label={
                     <Localize i18n_default_text='Growth rate' key={`growth-rate${is_minimized ? '-minimized' : ''}`} />
                 }
-                onClick={() => setIsOpen(true)}
+                onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+                    removeFocus(e);
+                    setIsOpen(true);
+                }}
                 readOnly
                 value={`${getGrowthRatePercentage(growth_rate)}%`}
                 variant='fill'

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.tsx
@@ -52,6 +52,7 @@ const LastDigitPrediction = observer(({ is_minimized }: TLastDigitSelectorProps)
                         removeFocus(e);
                         setIsOpen(true);
                     }}
+                    onMouseDown={removeFocus}
                 />
                 <ActionSheet.Root isOpen={is_open} onClose={onActionSheetClose} position='left' expandable={false}>
                     <ActionSheet.Portal shouldCloseOnDrag>

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from '@deriv/components';
 import { Localize } from '@deriv/translations';
 import { useTraderStore } from 'Stores/useTraderStores';
 import LastDigitSelector from './last-digit-selector';
+import { removeFocus } from 'AppV2/Utils/layout-utils';
 
 type TLastDigitSelectorProps = {
     is_minimized?: boolean;
@@ -47,7 +48,10 @@ const LastDigitPrediction = observer(({ is_minimized }: TLastDigitSelectorProps)
                     }
                     value={last_digit}
                     className={clsx('trade-params__option', 'trade-params__option--minimized')}
-                    onClick={() => setIsOpen(true)}
+                    onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+                        removeFocus(e);
+                        setIsOpen(true);
+                    }}
                 />
                 <ActionSheet.Root isOpen={is_open} onClose={onActionSheetClose} position='left' expandable={false}>
                     <ActionSheet.Portal shouldCloseOnDrag>

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.tsx
@@ -32,6 +32,7 @@ const LastDigitPrediction = observer(({ is_minimized }: TLastDigitSelectorProps)
     const onActionSheetClose = () => {
         setIsOpen(false);
         setSelectedDigit(last_digit);
+        removeFocus();
     };
 
     if (is_minimized)
@@ -52,7 +53,6 @@ const LastDigitPrediction = observer(({ is_minimized }: TLastDigitSelectorProps)
                         removeFocus(e);
                         setIsOpen(true);
                     }}
-                    onMouseDown={removeFocus}
                 />
                 <ActionSheet.Root isOpen={is_open} onClose={onActionSheetClose} position='left' expandable={false}>
                     <ActionSheet.Portal shouldCloseOnDrag>

--- a/packages/trader/src/AppV2/Components/TradeParameters/Multiplier/multiplier.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Multiplier/multiplier.tsx
@@ -72,6 +72,7 @@ const Multiplier = observer(({ is_minimized }: TMultiplierProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
+                onMouseDown={removeFocus}
             />
             <ActionSheet.Root
                 expandable={false}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Multiplier/multiplier.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Multiplier/multiplier.tsx
@@ -72,7 +72,6 @@ const Multiplier = observer(({ is_minimized }: TMultiplierProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
-                onMouseDown={removeFocus}
             />
             <ActionSheet.Root
                 expandable={false}
@@ -80,6 +79,7 @@ const Multiplier = observer(({ is_minimized }: TMultiplierProps) => {
                 position='left'
                 onClose={() => {
                     setIsOpen(false);
+                    removeFocus();
                 }}
             >
                 <ActionSheet.Portal shouldCloseOnDrag>

--- a/packages/trader/src/AppV2/Components/TradeParameters/Multiplier/multiplier.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Multiplier/multiplier.tsx
@@ -9,6 +9,7 @@ import CarouselHeader from 'AppV2/Components/Carousel/carousel-header';
 import TradeParamDefinition from 'AppV2/Components/TradeParamDefinition';
 import { isSmallScreen } from 'AppV2/Utils/trade-params-utils';
 import MultiplierWheelPicker from './multiplier-wheel-picker';
+import { removeFocus } from 'AppV2/Utils/layout-utils';
 
 type TMultiplierProps = {
     is_minimized?: boolean;
@@ -67,7 +68,10 @@ const Multiplier = observer(({ is_minimized }: TMultiplierProps) => {
                 }
                 value={`x${multiplier}`}
                 className={classname}
-                onClick={() => setIsOpen(true)}
+                onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+                    removeFocus(e);
+                    setIsOpen(true);
+                }}
             />
             <ActionSheet.Root
                 expandable={false}

--- a/packages/trader/src/AppV2/Components/TradeParameters/PayoutPerPoint/payout-per-point.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/PayoutPerPoint/payout-per-point.tsx
@@ -95,6 +95,7 @@ const PayoutPerPoint = observer(({ is_minimized }: TPayoutPerPointProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
+                onMouseDown={removeFocus}
                 readOnly
                 variant='fill'
                 value={`${v2_params_initial_values?.payout_per_point ?? payout_per_point} ${currency_display_code}`}

--- a/packages/trader/src/AppV2/Components/TradeParameters/PayoutPerPoint/payout-per-point.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/PayoutPerPoint/payout-per-point.tsx
@@ -11,6 +11,7 @@ import Carousel from 'AppV2/Components/Carousel';
 import CarouselHeader from 'AppV2/Components/Carousel/carousel-header';
 import TradeParamDefinition from 'AppV2/Components/TradeParamDefinition';
 import PayoutPerPointWheel from './payout-per-point-wheel';
+import { removeFocus } from 'AppV2/Utils/layout-utils';
 
 type TPayoutPerPointProps = {
     is_minimized?: boolean;
@@ -90,7 +91,10 @@ const PayoutPerPoint = observer(({ is_minimized }: TPayoutPerPointProps) => {
                         key={`payout-per-point${is_minimized ? '-minimized' : ''}`}
                     />
                 }
-                onClick={() => setIsOpen(true)}
+                onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+                    removeFocus(e);
+                    setIsOpen(true);
+                }}
                 readOnly
                 variant='fill'
                 value={`${v2_params_initial_values?.payout_per_point ?? payout_per_point} ${currency_display_code}`}

--- a/packages/trader/src/AppV2/Components/TradeParameters/PayoutPerPoint/payout-per-point.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/PayoutPerPoint/payout-per-point.tsx
@@ -95,12 +95,19 @@ const PayoutPerPoint = observer(({ is_minimized }: TPayoutPerPointProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
-                onMouseDown={removeFocus}
                 readOnly
                 variant='fill'
                 value={`${v2_params_initial_values?.payout_per_point ?? payout_per_point} ${currency_display_code}`}
             />
-            <ActionSheet.Root isOpen={is_open} onClose={() => setIsOpen(false)} position='left' expandable={false}>
+            <ActionSheet.Root
+                isOpen={is_open}
+                onClose={() => {
+                    setIsOpen(false);
+                    removeFocus();
+                }}
+                position='left'
+                expandable={false}
+            >
                 <ActionSheet.Portal shouldCloseOnDrag>
                     <Carousel
                         classname={clsx(

--- a/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/risk-management.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/risk-management.tsx
@@ -30,7 +30,10 @@ const RiskManagement = observer(({ is_minimized }: TRiskManagementProps) => {
         stop_loss,
     } = useTraderStore();
 
-    const closeActionSheet = () => setIsOpen(false);
+    const closeActionSheet = () => {
+        setIsOpen(false);
+        removeFocus();
+    };
     const getRiskManagementText = () => {
         if (has_cancellation) return `DC: ${addUnit({ value: cancellation_duration, unit: localize('minutes') })}`;
         if (has_take_profit && has_stop_loss)
@@ -84,7 +87,6 @@ const RiskManagement = observer(({ is_minimized }: TRiskManagementProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
-                onMouseDown={removeFocus}
                 readOnly
                 value={getRiskManagementText()}
                 variant='fill'

--- a/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/risk-management.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/risk-management.tsx
@@ -11,6 +11,7 @@ import TradeParamDefinition from 'AppV2/Components/TradeParamDefinition';
 import { addUnit, isSmallScreen } from 'AppV2/Utils/trade-params-utils';
 import RiskManagementPicker from './risk-management-picker';
 import RiskManagementContent from './risk-management-content';
+import { removeFocus } from 'AppV2/Utils/layout-utils';
 
 type TRiskManagementProps = {
     is_minimized?: boolean;
@@ -79,7 +80,10 @@ const RiskManagement = observer(({ is_minimized }: TRiskManagementProps) => {
                         key={`risk-management${is_minimized ? '-minimized' : ''}`}
                     />
                 }
-                onClick={() => setIsOpen(true)}
+                onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+                    removeFocus(e);
+                    setIsOpen(true);
+                }}
                 readOnly
                 value={getRiskManagementText()}
                 variant='fill'

--- a/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/risk-management.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/risk-management.tsx
@@ -84,6 +84,7 @@ const RiskManagement = observer(({ is_minimized }: TRiskManagementProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
+                onMouseDown={removeFocus}
                 readOnly
                 value={getRiskManagementText()}
                 variant='fill'

--- a/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
@@ -42,7 +42,6 @@ const Stake = observer(({ is_minimized }: TStakeProps) => {
     const [is_open, setIsOpen] = React.useState(false);
     const [should_show_error, setShouldShowError] = React.useState(true);
     const { available_contract_types } = useContractsForCompany();
-    const input_ref = React.useRef<HTMLInputElement>(null);
 
     // default_stake resetting data
     const is_crypto = isCryptocurrency(currency ?? '');
@@ -206,13 +205,12 @@ const Stake = observer(({ is_minimized }: TStakeProps) => {
                 label={<Localize i18n_default_text='Stake' key={`stake${is_minimized ? '-minimized' : ''}`} />}
                 noStatusIcon
                 onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
-                    removeFocus(e, input_ref);
+                    removeFocus(e);
                     setIsOpen(true);
                 }}
                 value={`${v2_params_initial_values?.stake ?? amount} ${getCurrencyDisplayCode(currency)}`}
                 className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
                 status={stake_error && !is_open ? 'error' : undefined}
-                ref={input_ref}
             />
             <ActionSheet.Root
                 isOpen={is_open}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
@@ -214,7 +214,15 @@ const Stake = observer(({ is_minimized }: TStakeProps) => {
                 status={stake_error && !is_open ? 'error' : undefined}
                 ref={input_ref}
             />
-            <ActionSheet.Root isOpen={is_open} onClose={() => onClose(false)} position='left' expandable={false}>
+            <ActionSheet.Root
+                isOpen={is_open}
+                onClose={() => {
+                    onClose(false);
+                    removeFocus();
+                }}
+                position='left'
+                expandable={false}
+            >
                 <ActionSheet.Portal shouldCloseOnDrag>
                     <ActionSheet.Header title={<Localize i18n_default_text='Stake' />} />
                     <ActionSheet.Content className='stake-content'>

--- a/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
@@ -207,6 +207,7 @@ const Stake = observer(({ is_minimized }: TStakeProps) => {
                 noStatusIcon
                 onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
                     removeFocus(e, input_ref);
+                    setIsOpen(true);
                 }}
                 value={`${v2_params_initial_values?.stake ?? amount} ${getCurrencyDisplayCode(currency)}`}
                 className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
@@ -8,6 +8,7 @@ import { useTraderStore } from 'Stores/useTraderStores';
 import { getDisplayedContractTypes } from 'AppV2/Utils/trade-types-utils';
 import StakeDetails from './stake-details';
 import useContractsForCompany from 'AppV2/Hooks/useContractsForCompany';
+import { removeFocus } from 'AppV2/Utils/layout-utils';
 
 type TStakeProps = {
     is_minimized?: boolean;
@@ -203,7 +204,10 @@ const Stake = observer(({ is_minimized }: TStakeProps) => {
                 readOnly
                 label={<Localize i18n_default_text='Stake' key={`stake${is_minimized ? '-minimized' : ''}`} />}
                 noStatusIcon
-                onClick={() => setIsOpen(true)}
+                onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+                    removeFocus(e);
+                    setIsOpen(true);
+                }}
                 value={`${v2_params_initial_values?.stake ?? amount} ${getCurrencyDisplayCode(currency)}`}
                 className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
                 status={stake_error && !is_open ? 'error' : undefined}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
@@ -208,6 +208,8 @@ const Stake = observer(({ is_minimized }: TStakeProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
+                onTouchCancel={removeFocus as unknown as (e: React.TouchEvent<HTMLInputElement>) => void}
+                onTouchEnd={removeFocus as unknown as (e: React.TouchEvent<HTMLInputElement>) => void}
                 value={`${v2_params_initial_values?.stake ?? amount} ${getCurrencyDisplayCode(currency)}`}
                 className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
                 status={stake_error && !is_open ? 'error' : undefined}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
@@ -208,8 +208,7 @@ const Stake = observer(({ is_minimized }: TStakeProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
-                onTouchCancel={removeFocus as unknown as (e: React.TouchEvent<HTMLInputElement>) => void}
-                onTouchEnd={removeFocus as unknown as (e: React.TouchEvent<HTMLInputElement>) => void}
+                onMouseDown={removeFocus}
                 value={`${v2_params_initial_values?.stake ?? amount} ${getCurrencyDisplayCode(currency)}`}
                 className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
                 status={stake_error && !is_open ? 'error' : undefined}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
@@ -207,11 +207,11 @@ const Stake = observer(({ is_minimized }: TStakeProps) => {
                 noStatusIcon
                 onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
                     removeFocus(e, input_ref);
-                    setIsOpen(true);
                 }}
                 value={`${v2_params_initial_values?.stake ?? amount} ${getCurrencyDisplayCode(currency)}`}
                 className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
                 status={stake_error && !is_open ? 'error' : undefined}
+                ref={input_ref}
             />
             <ActionSheet.Root isOpen={is_open} onClose={() => onClose(false)} position='left' expandable={false}>
                 <ActionSheet.Portal shouldCloseOnDrag>

--- a/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
@@ -42,6 +42,7 @@ const Stake = observer(({ is_minimized }: TStakeProps) => {
     const [is_open, setIsOpen] = React.useState(false);
     const [should_show_error, setShouldShowError] = React.useState(true);
     const { available_contract_types } = useContractsForCompany();
+    const input_ref = React.useRef<HTMLInputElement>(null);
 
     // default_stake resetting data
     const is_crypto = isCryptocurrency(currency ?? '');
@@ -205,10 +206,9 @@ const Stake = observer(({ is_minimized }: TStakeProps) => {
                 label={<Localize i18n_default_text='Stake' key={`stake${is_minimized ? '-minimized' : ''}`} />}
                 noStatusIcon
                 onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
-                    removeFocus(e);
+                    removeFocus(e, input_ref);
                     setIsOpen(true);
                 }}
-                onMouseDown={removeFocus}
                 value={`${v2_params_initial_values?.stake ?? amount} ${getCurrencyDisplayCode(currency)}`}
                 className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
                 status={stake_error && !is_open ? 'error' : undefined}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Strike/strike.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Strike/strike.tsx
@@ -102,6 +102,7 @@ const Strike = observer(({ is_minimized }: TStrikeProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
+                onMouseDown={removeFocus}
                 readOnly
                 variant='fill'
                 value={barrier_1}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Strike/strike.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Strike/strike.tsx
@@ -11,6 +11,7 @@ import Carousel from 'AppV2/Components/Carousel';
 import CarouselHeader from 'AppV2/Components/Carousel/carousel-header';
 import { isSmallScreen } from 'AppV2/Utils/trade-params-utils';
 import StrikeWheel from './strike-wheel';
+import { removeFocus } from 'AppV2/Utils/layout-utils';
 
 type TStrikeProps = {
     is_minimized?: boolean;
@@ -97,7 +98,10 @@ const Strike = observer(({ is_minimized }: TStrikeProps) => {
             <TextField
                 className={classname}
                 label={<Localize i18n_default_text='Strike price' key={`strike${is_minimized ? '-minimized' : ''}`} />}
-                onClick={() => setIsOpen(true)}
+                onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+                    removeFocus(e);
+                    setIsOpen(true);
+                }}
                 readOnly
                 variant='fill'
                 value={barrier_1}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Strike/strike.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Strike/strike.tsx
@@ -102,12 +102,19 @@ const Strike = observer(({ is_minimized }: TStrikeProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
-                onMouseDown={removeFocus}
                 readOnly
                 variant='fill'
                 value={barrier_1}
             />
-            <ActionSheet.Root isOpen={is_open} onClose={() => setIsOpen(false)} position='left' expandable={false}>
+            <ActionSheet.Root
+                isOpen={is_open}
+                onClose={() => {
+                    setIsOpen(false);
+                    removeFocus();
+                }}
+                position='left'
+                expandable={false}
+            >
                 <ActionSheet.Portal shouldCloseOnDrag>
                     <Carousel
                         classname={clsx('strike__carousel', is_small_screen && 'strike__carousel--small')}

--- a/packages/trader/src/AppV2/Components/TradeParameters/TakeProfit/take-profit.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/TakeProfit/take-profit.tsx
@@ -20,7 +20,10 @@ const TakeProfit = observer(({ is_minimized }: TTakeProfitProps) => {
 
     const [is_open, setIsOpen] = React.useState(false);
 
-    const onActionSheetClose = () => setIsOpen(false);
+    const onActionSheetClose = () => {
+        setIsOpen(false);
+        removeFocus();
+    };
 
     const action_sheet_content = [
         {
@@ -51,7 +54,6 @@ const TakeProfit = observer(({ is_minimized }: TTakeProfitProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
-                onMouseDown={removeFocus}
                 readOnly
                 variant='fill'
                 value={has_take_profit && take_profit ? `${take_profit} ${getCurrencyDisplayCode(currency)}` : '-'}

--- a/packages/trader/src/AppV2/Components/TradeParameters/TakeProfit/take-profit.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/TakeProfit/take-profit.tsx
@@ -9,6 +9,7 @@ import Carousel from 'AppV2/Components/Carousel';
 import CarouselHeader from 'AppV2/Components/Carousel/carousel-header';
 import TakeProfitAndStopLossInput from '../RiskManagement/take-profit-and-stop-loss-input';
 import TradeParamDefinition from 'AppV2/Components/TradeParamDefinition';
+import { removeFocus } from 'AppV2/Utils/layout-utils';
 
 type TTakeProfitProps = {
     is_minimized?: boolean;
@@ -46,7 +47,10 @@ const TakeProfit = observer(({ is_minimized }: TTakeProfitProps) => {
                 label={
                     <Localize i18n_default_text='Take profit' key={`take-profit${is_minimized ? '-minimized' : ''}`} />
                 }
-                onClick={() => setIsOpen(true)}
+                onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+                    removeFocus(e);
+                    setIsOpen(true);
+                }}
                 readOnly
                 variant='fill'
                 value={has_take_profit && take_profit ? `${take_profit} ${getCurrencyDisplayCode(currency)}` : '-'}

--- a/packages/trader/src/AppV2/Components/TradeParameters/TakeProfit/take-profit.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/TakeProfit/take-profit.tsx
@@ -51,6 +51,7 @@ const TakeProfit = observer(({ is_minimized }: TTakeProfitProps) => {
                     removeFocus(e);
                     setIsOpen(true);
                 }}
+                onMouseDown={removeFocus}
                 readOnly
                 variant='fill'
                 value={has_take_profit && take_profit ? `${take_profit} ${getCurrencyDisplayCode(currency)}` : '-'}

--- a/packages/trader/src/AppV2/Utils/__tests__/layout-utils.spec.tsx
+++ b/packages/trader/src/AppV2/Utils/__tests__/layout-utils.spec.tsx
@@ -1,5 +1,8 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { TRADE_TYPES } from '@deriv/shared';
-import { isTradeParamVisible, getChartHeight } from '../layout-utils';
+import { isTradeParamVisible, getChartHeight, removeFocus } from '../layout-utils';
 
 describe('isTradeParamVisible', () => {
     it('should return correct value for expiration component key', () => {
@@ -130,5 +133,19 @@ describe('getChartHeight', () => {
                 contract_type: TRADE_TYPES.HIGH_LOW,
             })
         ).toEqual(chart_height_with_additional_info);
+    });
+});
+
+describe('removeFocus', () => {
+    it('removes focus from the element', () => {
+        const MockComponent = () => (
+            <input type='text' onClick={(e: React.MouseEvent<HTMLInputElement, MouseEvent>) => removeFocus(e)} />
+        );
+        render(<MockComponent />);
+
+        const input = screen.getByRole('textbox');
+        userEvent.click(input);
+
+        expect(input).not.toHaveFocus();
     });
 });

--- a/packages/trader/src/AppV2/Utils/__tests__/trade-param-utils.spec.tsx
+++ b/packages/trader/src/AppV2/Utils/__tests__/trade-param-utils.spec.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode } from 'react';
+import React, { ReactElement } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CONTRACT_TYPES, TRADE_TYPES } from '@deriv/shared';

--- a/packages/trader/src/AppV2/Utils/layout-utils.tsx
+++ b/packages/trader/src/AppV2/Utils/layout-utils.tsx
@@ -50,3 +50,8 @@ export const getChartHeight = ({
         return height - HEIGHT.ADDITIONAL_INFO;
     return height;
 };
+
+export const removeFocus = (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+    e.preventDefault();
+    (e.target as HTMLElement).blur();
+};

--- a/packages/trader/src/AppV2/Utils/layout-utils.tsx
+++ b/packages/trader/src/AppV2/Utils/layout-utils.tsx
@@ -52,9 +52,10 @@ export const getChartHeight = ({
 };
 
 export const removeFocus = (
-    e: React.MouseEvent<HTMLInputElement, MouseEvent>,
+    e?: React.MouseEvent<HTMLInputElement, MouseEvent>,
     ref?: React.RefObject<HTMLInputElement>
 ) => {
-    (e.target as HTMLElement)?.blur();
+    (e?.target as HTMLElement)?.blur();
     ref?.current?.blur();
+    (document?.activeElement as HTMLElement)?.blur();
 };

--- a/packages/trader/src/AppV2/Utils/layout-utils.tsx
+++ b/packages/trader/src/AppV2/Utils/layout-utils.tsx
@@ -51,7 +51,4 @@ export const getChartHeight = ({
     return height;
 };
 
-export const removeFocus = (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
-    e.preventDefault();
-    (e.target as HTMLElement)?.blur();
-};
+export const removeFocus = (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => (e.target as HTMLElement)?.blur();

--- a/packages/trader/src/AppV2/Utils/layout-utils.tsx
+++ b/packages/trader/src/AppV2/Utils/layout-utils.tsx
@@ -51,4 +51,10 @@ export const getChartHeight = ({
     return height;
 };
 
-export const removeFocus = (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => (e.target as HTMLElement)?.blur();
+export const removeFocus = (
+    e: React.MouseEvent<HTMLInputElement, MouseEvent>,
+    ref?: React.RefObject<HTMLInputElement>
+) => {
+    (e.target as HTMLElement)?.blur();
+    ref?.current?.blur();
+};

--- a/packages/trader/src/AppV2/Utils/layout-utils.tsx
+++ b/packages/trader/src/AppV2/Utils/layout-utils.tsx
@@ -53,5 +53,5 @@ export const getChartHeight = ({
 
 export const removeFocus = (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
     e.preventDefault();
-    (e.target as HTMLElement).blur();
+    (e.target as HTMLElement)?.blur();
 };


### PR DESCRIPTION
## Changes:

- Fixed scrolling issue: because trade params components were built around the input field, they got focus on click and that caused scrolling issue. Only in cases, when inside of ActionSheet (which opens on trade param click) there was Wheel Picker, which caught focus, scrolling was working as expected.  ===> Created a function, which removes focus. 
- Added test.


### Screenshots:

![Screenshot 2024-10-14 at 11 05 07 AM](https://github.com/user-attachments/assets/335837bb-83af-427f-9d4b-19dacc5f113d)

https://github.com/user-attachments/assets/3eba8036-e03a-4914-a712-8ab15839edd8
