### PR TITLE
[TRAH] [CFDS] [WALL] shontzu/CFDS-4566/TrackJs-error-Right-side-of-assignment-cannot-be-destructured

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
                 "dompurify": "^3.1.0",
                 "dotenv": "^8.2.0",
                 "downshift": "^8.2.2",
-                "embla-carousel-react": "8.0.0-rc12",
+                "embla-carousel-react": "8.3.0",
                 "eslint-config-airbnb-base": "^14.2.1",
                 "eslint-config-binary": "^1.0.2",
                 "eslint-config-prettier": "^7.2.0",
@@ -27023,28 +27023,28 @@
             "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw=="
         },
         "node_modules/embla-carousel": {
-            "version": "8.0.0-rc12",
-            "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.0.0-rc12.tgz",
-            "integrity": "sha512-/Xkf5zp9gs9Y45lSAT1Witn+r+o+EtoIIZg4V2lYTCaaqdDTxyO0Ddn+z00ya38JGNZrGH9U8wLGK5Hi76CRxw=="
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.3.0.tgz",
+            "integrity": "sha512-Ve8dhI4w28qBqR8J+aMtv7rLK89r1ZA5HocwFz6uMB/i5EiC7bGI7y+AM80yAVUJw3qqaZYK7clmZMUR8kM3UA=="
         },
         "node_modules/embla-carousel-react": {
-            "version": "8.0.0-rc12",
-            "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.0.0-rc12.tgz",
-            "integrity": "sha512-Tyd9TNH9i8bb/0S9/WZsmEvfZm8jlFU9sgaWNNgLzbPsUtz/L6UTYuRGOBDOt2oh6VPhaL1G8vRuOAuH81G5Cg==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.3.0.tgz",
+            "integrity": "sha512-P1FlinFDcIvggcErRjNuVqnUR8anyo8vLMIH8Rthgofw7Nj8qTguCa2QjFAbzxAUTQTPNNjNL7yt0BGGinVdFw==",
             "dependencies": {
-                "embla-carousel": "8.0.0-rc12",
-                "embla-carousel-reactive-utils": "8.0.0-rc12"
+                "embla-carousel": "8.3.0",
+                "embla-carousel-reactive-utils": "8.3.0"
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.1 || ^18.0.0"
             }
         },
         "node_modules/embla-carousel-reactive-utils": {
-            "version": "8.0.0-rc12",
-            "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.0.0-rc12.tgz",
-            "integrity": "sha512-sHYqMYW2qk9UXNMLoBmo4PRe+8qOW8CJDDqfkMB0WlSfrzgi9fCc36nArQz6k9olHsVfEc3haw00KiqRBvVwEg==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.3.0.tgz",
+            "integrity": "sha512-EYdhhJ302SC4Lmkx8GRsp0sjUhEN4WyFXPOk0kGu9OXZSRMmcBlRgTvHcq8eKJE1bXWBsOi1T83B+BSSVZSmwQ==",
             "peerDependencies": {
-                "embla-carousel": "8.0.0-rc12"
+                "embla-carousel": "8.3.0"
             }
         },
         "node_modules/emittery": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -82,7 +82,7 @@
         "@types/react-virtualized": "^9.21.21",
         "classnames": "^2.2.6",
         "clsx": "^2.1.1",
-        "embla-carousel-react": "8.0.0-rc12",
+        "embla-carousel-react": "8.3.0",
         "framer-motion": "^6.5.1",
         "gh-pages": "^6.1.1",
         "glob": "^7.1.5",

--- a/packages/components/src/components/cfd-compare-accounts-carousel/cfd-compare-accounts-carousel.tsx
+++ b/packages/components/src/components/cfd-compare-accounts-carousel/cfd-compare-accounts-carousel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import useEmblaCarousel, { EmblaCarouselType, EmblaOptionsType } from 'embla-carousel-react';
+import useEmblaCarousel from 'embla-carousel-react';
+import type { EmblaCarouselType, EmblaOptionsType } from 'embla-carousel';
 import CFDCompareAccountsCarouselButton from './cfd-compare-accounts-carousel-button';
 
 type TCFDCompareAccountsCarousel = {
@@ -9,7 +10,7 @@ type TCFDCompareAccountsCarousel = {
 
 const CFDCompareAccountsCarousel = ({ children, isRtl = false }: TCFDCompareAccountsCarousel) => {
     const options: EmblaOptionsType = {
-        align: 0,
+        align: 'start',
         containScroll: 'trimSnaps',
         direction: isRtl ? 'rtl' : 'ltr',
     };

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -27,7 +27,7 @@
         "classnames": "^2.2.6",
         "crc-32": "^1.2.0",
         "downshift": "^8.2.2",
-        "embla-carousel-react": "8.0.0-rc12",
+        "embla-carousel-react": "8.3.0",
         "formik": "^2.1.4",
         "qrcode.react": "^3.1.0",
         "react": "^17.0.2",

--- a/packages/wallets/src/components/WalletsAddMoreCarousel/WalletsAddMoreCarousel.tsx
+++ b/packages/wallets/src/components/WalletsAddMoreCarousel/WalletsAddMoreCarousel.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import useEmblaCarousel, { EmblaCarouselType } from 'embla-carousel-react';
+import useEmblaCarousel from 'embla-carousel-react';
+import type { EmblaCarouselType } from 'embla-carousel';
 import { useHover } from 'usehooks-ts';
 import { useAllWalletAccounts, useAuthorize } from '@deriv/api-v2';
 import { LabelPairedChevronLeftLgFillIcon, LabelPairedChevronRightLgFillIcon } from '@deriv/quill-icons';
@@ -20,7 +21,7 @@ const WalletsAddMoreCarousel: React.FC = () => {
     const showLoader = isInitializing || isLoading;
 
     const [walletsAddMoreEmblaRef, walletsAddMoreEmblaAPI] = useEmblaCarousel({
-        align: 0,
+        align: 'start',
         containScroll: 'trimSnaps',
         direction: isRtl ? 'rtl' : 'ltr',
     });

--- a/packages/wallets/src/components/WalletsCarouselContent/WalletsCarouselContent.tsx
+++ b/packages/wallets/src/components/WalletsCarouselContent/WalletsCarouselContent.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import useEmblaCarousel, { EmblaCarouselType, EmblaEventType } from 'embla-carousel-react';
+import useEmblaCarousel from 'embla-carousel-react';
+import type { EmblaCarouselType, EmblaEventType } from 'embla-carousel';
 import { useHistory } from 'react-router-dom';
 import { useActiveWalletAccount, useCurrencyConfig, useMobileCarouselWalletsList } from '@deriv/api-v2';
 import { displayMoney } from '@deriv/api-v2/src/utils';

--- a/packages/wallets/src/features/cfd/components/CompareAccountsCarousel/CompareAccountsCarousel.tsx
+++ b/packages/wallets/src/features/cfd/components/CompareAccountsCarousel/CompareAccountsCarousel.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import useEmblaCarousel, { EmblaCarouselType, EmblaOptionsType } from 'embla-carousel-react';
+import useEmblaCarousel from 'embla-carousel-react';
+import type { EmblaCarouselType, EmblaOptionsType } from 'embla-carousel';
 import CFDCompareAccountsCarouselButton from './CompareAccountsCarouselButton';
 import './CompareAccountsCarousel.scss';
 
@@ -10,7 +11,7 @@ type TCompareAccountsCarousel = {
 
 const CompareAccountsCarousel = ({ children, isRtl = false }: TCompareAccountsCarousel) => {
     const options: EmblaOptionsType = {
-        align: 0,
+        align: 'start',
         containScroll: 'trimSnaps',
         direction: isRtl ? 'rtl' : 'ltr',
     };


### PR DESCRIPTION
## Changes:

- trackjs error is coming from embla which is used by the carousel in compare-accounts page
- https://www.npmjs.com/package/embla-carousel

### Screenshots:

![image](https://github.com/user-attachments/assets/5e2ea5b1-7e13-4b16-9078-da8ee8708fd6)

