### PR TITLE
[UPM1701] Suisin/chore: upgrade quill-icons package and fix the breaking icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "@deriv/deriv-charts": "^2.5.1",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
-                "@deriv/quill-icons": "1.23.3",
+                "@deriv/quill-icons": "2.1.2",
                 "@lottiefiles/dotlottie-react": "0.7.2",
                 "@sendbird/chat": "^4.9.7",
                 "@simplewebauthn/browser": "^8.3.4",
@@ -3038,6 +3038,15 @@
                 "remove": "^0.1.5"
             }
         },
+        "node_modules/@deriv-com/quill-ui/node_modules/@deriv/quill-icons": {
+            "version": "1.23.14",
+            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.23.14.tgz",
+            "integrity": "sha512-I9rajWDuN6Yoqj5atWS1djVFuAQDRV7U5ZOencpYNc8JBrv96eWq+eVNHk1eeSy5QSIyxhh6aKnz59V3ViVBnA==",
+            "peerDependencies": {
+                "react": ">= 16",
+                "react-dom": ">= 16"
+            }
+        },
         "node_modules/@deriv-com/quill-ui/node_modules/@headlessui/react": {
             "version": "1.7.18",
             "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.18.tgz",
@@ -3456,10 +3465,9 @@
             }
         },
         "node_modules/@deriv/quill-icons": {
-            "version": "1.23.3",
-            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.23.3.tgz",
-            "integrity": "sha512-xCjtZuFC6EAz0vFljzIkHZfLoKH0YTO9IuollwTCjj8tLY/3Lam998MvPO4zEFU6el1A6/rLjqiqlQXciSKT9w==",
-            "license": "ISC",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-2.1.2.tgz",
+            "integrity": "sha512-CUiItM0SkN5jRfy1cM0SF5ATg8ClCjGhVDY2f6YXh5n1HBPftCN3KoB/OTVckkFjcoR8morS1WGwHC41sa7BBg==",
             "peerDependencies": {
                 "react": ">= 16",
                 "react-dom": ">= 16"

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -38,7 +38,7 @@
         "@deriv-com/quill-ui": "1.18.0",
         "@deriv/components": "^1.0.0",
         "@deriv/hooks": "^1.0.0",
-        "@deriv/quill-icons": "1.23.3",
+        "@deriv/quill-icons": "2.1.2",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -81,7 +81,7 @@
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",
-        "@deriv/quill-icons": "1.23.3",
+        "@deriv/quill-icons": "2.1.2",
         "blockly": "^10.4.3",
         "@testing-library/user-event": "^13.5.0",
         "@types/react-router-dom": "^5.1.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -114,7 +114,7 @@
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/quill-design": "^1.3.2",
-        "@deriv/quill-icons": "1.23.3",
+        "@deriv/quill-icons": "2.1.2",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -47,7 +47,7 @@
     },
     "dependencies": {
         "@deriv-com/analytics": "1.14.0",
-        "@deriv/quill-icons": "1.23.3",
+        "@deriv/quill-icons": "2.1.2",
         "@deriv/api-types": "1.0.172",
         "@deriv/translations": "^1.0.0",
         "@deriv-com/utils": "^0.0.36",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -102,7 +102,7 @@
         "@deriv/stores": "^1.0.0",
         "@deriv/translations": "^1.0.0",
         "@deriv/utils": "^1.0.0",
-        "@deriv/quill-icons": "1.23.3",
+        "@deriv/quill-icons": "2.1.2",
         "@lottiefiles/dotlottie-react": "0.7.2",
         "@types/react-loadable": "^5.5.6",
         "classnames": "^2.2.6",

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -19,7 +19,7 @@
         "@deriv-com/ui": "1.36.4",
         "@deriv-com/utils": "^0.0.36",
         "@deriv/api-v2": "^1.0.0",
-        "@deriv/quill-icons": "1.23.3",
+        "@deriv/quill-icons": "2.1.2",
         "@deriv/utils": "^1.0.0",
         "@tanstack/react-table": "^8.10.3",
         "@zxcvbn-ts/core": "^3.0.4",

--- a/packages/wallets/src/constants/icons.ts
+++ b/packages/wallets/src/constants/icons.ts
@@ -17,10 +17,10 @@ import {
     CurrencyUsdIcon,
     CurrencyUsdtIcon,
     CurrencyXrpIcon,
-    DerivProductDerivBotBrandLightLogoHorizontalIcon,
-    DerivProductDerivGoBrandLightLogoHorizontalIcon,
-    DerivProductDerivTraderBrandLightLogoHorizontalIcon,
-    PartnersProductSmarttraderBrandLightLogoIcon,
+    DerivProductBrandLightDerivBotLogoIcon,
+    DerivProductBrandLightDerivGoLogoIcon,
+    DerivProductBrandLightDerivTraderLogoIcon,
+    PartnersProductBrandLightSmarttraderLogoIcon,
     PaymentMethodBitcoinBrandIcon,
     PaymentMethodDerivDemoBrandDarkIcon,
     PaymentMethodEthereumBrandIcon,
@@ -32,10 +32,10 @@ import {
 import { TCurrencyIconTypes, TIconTypes } from '../types';
 
 export const AppIcons: TIconTypes = {
-    bot: DerivProductDerivBotBrandLightLogoHorizontalIcon,
-    derivgo: DerivProductDerivGoBrandLightLogoHorizontalIcon,
-    smarttrader: PartnersProductSmarttraderBrandLightLogoIcon,
-    trader: DerivProductDerivTraderBrandLightLogoHorizontalIcon,
+    bot: DerivProductBrandLightDerivBotLogoIcon,
+    derivgo: DerivProductBrandLightDerivGoLogoIcon,
+    smarttrader: PartnersProductBrandLightSmarttraderLogoIcon,
+    trader: DerivProductBrandLightDerivTraderLogoIcon,
 };
 
 export const CFDPlatformIcons: TIconTypes = {

--- a/packages/wallets/src/features/accounts/modules/DocumentService/components/Onfido/Onfido.tsx
+++ b/packages/wallets/src/features/accounts/modules/DocumentService/components/Onfido/Onfido.tsx
@@ -80,7 +80,7 @@ const Onfido: React.FC<TOnfidoProps> = ({ onClickBack, onCompletion }) => {
                     ) : (
                         <InlineMessage
                             className='wallets-onfido__wrapper-banner'
-                            icon={<LegacyAnnouncementIcon iconSize='xs' />}
+                            icon={<LegacyAnnouncementIcon fill='#4BB4B3' iconSize='xs' />}
                         >
                             <Text size='2xs'>
                                 <Localize i18n_default_text='Your personal details have been saved successfully.' />

--- a/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.tsx
+++ b/packages/wallets/src/features/cashier/modules/TransactionStatus/TransactionStatus.tsx
@@ -50,7 +50,7 @@ const TransactionStatus: React.FC<TTransactionStatus> = ({ transactionType }) =>
                 <Text align='start' size='sm' weight='bold'>
                     <Localize i18n_default_text='Transaction status' />
                 </Text>
-                {isError && <LegacyWarningIcon iconSize='xs' />}
+                {isError && <LegacyWarningIcon fill='#FFAD3A' iconSize='xs' />}
             </div>
             <Divider color='var(--general-active)' />
             <div className='wallets-transaction-status__body'>

--- a/packages/wallets/src/features/cfd/components/PlatformStatusBadge/PlatformStatusBadge.tsx
+++ b/packages/wallets/src/features/cfd/components/PlatformStatusBadge/PlatformStatusBadge.tsx
@@ -36,7 +36,7 @@ const PlatformStatusBadge: React.FC<TProps> = ({ badgeSize, cashierAccount, clas
             className={className}
             color='warning'
             isBold
-            leftIcon={<LegacyWarningIcon iconSize='xs' />}
+            leftIcon={<LegacyWarningIcon fill='#FFAD3A' iconSize='xs' />}
             padding='loose'
             rounded='sm'
             variant='bordered'

--- a/packages/wallets/src/features/cfd/constants.tsx
+++ b/packages/wallets/src/features/cfd/constants.tsx
@@ -6,12 +6,12 @@ import {
     AccountsDmt5StandardIcon,
     AccountsDmt5SwfIcon,
     AccountsDmt5ZrsIcon,
-    DerivProductDerivXBrandDarkWordmarkIcon,
+    DerivProductBrandDarkDerivXWordmarkIcon,
     LabelPairedLinuxXlIcon,
     LabelPairedMacosXlIcon,
     LabelPairedWindowsXlIcon,
-    PartnersProductDerivCtraderBrandDarkWordmarkHorizontalIcon,
-    PartnersProductDerivMt5BrandLightLogoHorizontalIcon,
+    PartnersProductBrandDarkDerivCtraderLogoWordmarkIcon,
+    PartnersProductBrandLightDerivMt5LogoIcon,
 } from '@deriv/quill-icons';
 import { localize, useTranslations } from '@deriv-com/translations';
 import { THooks, TPlatforms } from '../../types';
@@ -107,7 +107,7 @@ export const getAppToContentMapper = (localize: ReturnType<typeof useTranslation
             title: localize('MetaTrader 5 MacOS app'),
         },
         web: {
-            icon: <PartnersProductDerivMt5BrandLightLogoHorizontalIcon height={32} width={32} />,
+            icon: <PartnersProductBrandLightDerivMt5LogoIcon height={32} width={32} />,
             link: whiteLabelLinks.webtrader_url,
             text: localize('Open'),
             title: localize('MetaTrader 5 web'),
@@ -121,8 +121,8 @@ export const getAppToContentMapper = (localize: ReturnType<typeof useTranslation
     } as const);
 
 export const PlatformToLabelIconMapper = {
-    ctrader: <PartnersProductDerivCtraderBrandDarkWordmarkHorizontalIcon height={8} width={58} />,
-    dxtrade: <DerivProductDerivXBrandDarkWordmarkIcon height={10} width={35} />,
+    ctrader: <PartnersProductBrandDarkDerivCtraderLogoWordmarkIcon height={8} width={58} />,
+    dxtrade: <DerivProductBrandDarkDerivXWordmarkIcon height={10} width={35} />,
 } as const;
 
 export const getServiceMaintenanceMessages = (localize: ReturnType<typeof useTranslations>['localize']) =>

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/constants.tsx
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/constants.tsx
@@ -6,7 +6,7 @@ import {
     AccountsDmt5StandardIcon,
     AccountsDmt5SwfIcon,
     AccountsDmt5ZrsIcon,
-    PartnersProductDerivCtraderBrandLightLogoHorizontalIcon,
+    PartnersProductBrandLightDerivCtraderLogoIcon,
 } from '@deriv/quill-icons';
 import { useTranslations } from '@deriv-com/translations';
 import { CFD_PLATFORMS, MARKET_TYPE, PRODUCT } from '../../constants';
@@ -16,7 +16,7 @@ export const ACCOUNT_ICONS = {
     [MARKET_TYPE.FINANCIAL]: <AccountsDmt5FinancialIcon iconSize='lg' />,
     [MARKET_TYPE.ALL]: <AccountsDmt5SwfIcon iconSize='lg' />,
     [CFD_PLATFORMS.DXTRADE]: <AccountsDerivXIcon iconSize='lg' />,
-    [CFD_PLATFORMS.CTRADER]: <PartnersProductDerivCtraderBrandLightLogoHorizontalIcon height={48} width={48} />,
+    [CFD_PLATFORMS.CTRADER]: <PartnersProductBrandLightDerivCtraderLogoIcon height={48} width={48} />,
     [PRODUCT.ZEROSPREAD]: <AccountsDmt5ZrsIcon iconSize='lg' />,
     default: <AccountsDmt5CfdsIcon iconSize='lg' />,
 } as const;


### PR DESCRIPTION
## Changes:

upgrade quill-icons package and fix the breaking icons.

### Screenshots:

![Screenshot 2024-10-21 at 3 16 43 PM](https://github.com/user-attachments/assets/0a115e2f-4fc6-4c9d-9ae4-d77170cbcd92)
![Screenshot 2024-10-21 at 3 22 47 PM](https://github.com/user-attachments/assets/b22ae6ee-94f9-4d09-83ca-579d0b11be0f)
![Screenshot 2024-10-21 at 3 27 49 PM](https://github.com/user-attachments/assets/fa0f83c2-a79b-4739-8ee8-efe0bcec1af6)
![Screenshot 2024-10-21 at 3 35 57 PM](https://github.com/user-attachments/assets/49edb3c9-748c-4c2f-9f5e-f7780c86ad53)
![Screenshot 2024-10-21 at 3 50 54 PM](https://github.com/user-attachments/assets/02e29ecd-ebb7-4b5c-8e1a-37064f75a9db)

