### PR TITLE
DTRA-2208 / Kate / [Dtrader-V2]There is no error message for disabled symbol from BO

### DIFF
--- a/packages/trader/src/AppV2/Components/ServicesErrorSnackbar/__tests__/services-error-snackbar.spec.tsx
+++ b/packages/trader/src/AppV2/Components/ServicesErrorSnackbar/__tests__/services-error-snackbar.spec.tsx
@@ -5,6 +5,7 @@ import { useSnackbar } from '@deriv-com/quill-ui';
 import { useLocation } from 'react-router';
 import TraderProviders from '../../../../trader-providers';
 import ServicesErrorSnackbar from '../services-error-snackbar';
+import { CONTRACT_TYPES, TRADE_TYPES } from '@deriv/shared';
 
 jest.mock('@deriv-com/quill-ui', () => ({
     ...jest.requireActual('@deriv-com/quill-ui'),
@@ -50,6 +51,49 @@ describe('ServicesErrorSnackbar', () => {
         (useLocation as jest.Mock).mockReturnValue({
             pathname: '/dtrader',
         });
+        render(mockServicesErrorSnackbar());
+
+        expect(mockAddSnackbar).toHaveBeenCalled();
+    });
+
+    it('calls useSnackbar if it is trading page and there is an error without error_field in proposal_info and arrays in validation_errors are empty', () => {
+        (useLocation as jest.Mock).mockReturnValue({
+            pathname: '/dtrader',
+        });
+        default_mock_store.common.services_error = {};
+        default_mock_store.modules.trade = {
+            proposal_info: {
+                [CONTRACT_TYPES.MULTIPLIER.UP]: {
+                    id: '',
+                    has_error: true,
+                    has_error_details: false,
+                    error_code: 'ContractBuyValidationError',
+                    message: 'This trade is temporarily unavailable.',
+                    obj_contract_basis: {
+                        text: '',
+                        value: '',
+                    },
+                },
+            },
+            trade_types: {
+                [CONTRACT_TYPES.MULTIPLIER.DOWN]: 'Multiply Down',
+                [CONTRACT_TYPES.MULTIPLIER.UP]: 'Multiply Up',
+            },
+            contract_type: TRADE_TYPES.MULTIPLIER,
+            trade_type_tab: '',
+            validation_errors: {
+                stop_loss: [],
+                take_profit: [],
+                amount: [],
+                barrier_1: [],
+                barrier_2: [],
+                duration: [],
+                start_date: [],
+                start_time: [],
+                expiry_date: [],
+                expiry_time: [],
+            },
+        };
         render(mockServicesErrorSnackbar());
 
         expect(mockAddSnackbar).toHaveBeenCalled();

--- a/packages/trader/src/AppV2/Components/ServicesErrorSnackbar/services-error-snackbar.tsx
+++ b/packages/trader/src/AppV2/Components/ServicesErrorSnackbar/services-error-snackbar.tsx
@@ -6,6 +6,7 @@ import { useSnackbar, SnackbarController } from '@deriv-com/quill-ui';
 import { isEmptyObject, isValidToCancel, routes } from '@deriv/shared';
 import useContractDetails from 'AppV2/Hooks/useContractDetails';
 import { checkIsServiceModalError } from 'AppV2/Utils/layout-utils';
+import { getDisplayedContractTypes } from 'AppV2/Utils/trade-types-utils';
 
 const ServicesErrorSnackbar = observer(() => {
     const {
@@ -13,7 +14,8 @@ const ServicesErrorSnackbar = observer(() => {
         ui: { is_mf_verification_pending_modal_visible },
         client: { is_logged_in },
     } = useStore();
-    const { is_multiplier } = useTraderStore();
+    const { is_multiplier, proposal_info, validation_errors, trade_types, contract_type, trade_type_tab } =
+        useTraderStore();
     const { contract_info } = useContractDetails();
     const { addSnackbar } = useSnackbar();
     const { pathname } = useLocation();
@@ -21,10 +23,18 @@ const ServicesErrorSnackbar = observer(() => {
     const { message } = services_error || {};
     const has_services_error = !isEmptyObject(services_error);
     const is_modal_error = checkIsServiceModalError({ services_error, is_mf_verification_pending_modal_visible });
+    const contract_type_object = getDisplayedContractTypes(trade_types, contract_type, trade_type_tab);
+
+    // Some BO errors comes inside of proposal and we store them inside of proposal_info.
+    // Such error have no error_field and it is one of the main differences from trade parameters errors (duration, stake and etc).
+    // Another difference is that trade params errors arrays in validation_errors are empty.
+    const { has_error, error_field, message: contract_error_message } = proposal_info[contract_type_object[0]] ?? {};
+    const contract_error =
+        has_error && !error_field && !Object.keys(validation_errors).some(key => validation_errors[key].length);
 
     const checkShouldShowErrorSnackBar = () => {
-        if (!has_services_error) return false;
-        if (pathname === routes.trade) return has_services_error && !is_modal_error;
+        if (!has_services_error && !contract_error) return false;
+        if (pathname === routes.trade) return (has_services_error && !is_modal_error) || contract_error;
         if (pathname === routes.trader_positions || location.pathname.startsWith('/contract/'))
             return has_services_error;
         return false;
@@ -38,7 +48,7 @@ const ServicesErrorSnackbar = observer(() => {
     React.useEffect(() => {
         if (should_show_error_snackbar) {
             addSnackbar({
-                message,
+                message: message ?? contract_error_message,
                 status: 'fail',
                 hasCloseButton: true,
                 hasFixedHeight: false,


### PR DESCRIPTION
## Changes:

- Added BO error handler: it turns out, some that BO errors are coming not inside of the `services_error`, but inside of `proposal_info` for a proper trade type.  Such errors have no `error_field` and it is one of the main differences from trade parameters errors (because they have `error_field` such as `duration`, `stake` and etc. Another difference is that trade params errors arrays in `validation_errors` are empty.
- Added tests cases

### Screenshots:

https://github.com/user-attachments/assets/cb89bbcb-fe09-4c3a-ac5b-8e9bc7c7eb68

