### PR TITLE
[WALL] Jim/WALL-4851/display migration note or disclaimer on no pa p2p access post

### DIFF
--- a/packages/appstore/src/components/modals/wallets-upgrade-modal/wallets-upgrade-modal.scss
+++ b/packages/appstore/src/components/modals/wallets-upgrade-modal/wallets-upgrade-modal.scss
@@ -53,6 +53,13 @@
         gap: 0.8rem;
     }
 
+    &__disclaimer {
+        width: 100%;
+        &-message {
+            line-height: 2.2rem;
+        }
+    }
+
     &__footer {
         &--mobile {
             text-align: center;

--- a/packages/appstore/src/components/modals/wallets-upgrade-modal/wallets-upgrade-modal.tsx
+++ b/packages/appstore/src/components/modals/wallets-upgrade-modal/wallets-upgrade-modal.tsx
@@ -5,6 +5,7 @@ import { Button, Text, Modal, VideoPlayer } from '@deriv/components';
 import { localize, Localize } from '@deriv/translations';
 import { observer, useStore } from '@deriv/stores';
 import { useWalletMigration } from '@deriv/hooks';
+import { SectionMessage } from '@deriv-com/ui';
 import {
     getWalletMigrationVideoTranslations,
     WALLET_MIGRATION_VIDEO_TRANSLATIONS,
@@ -91,6 +92,11 @@ const WalletsUpgradeModal = observer(() => {
                             />
                         </Text>
                     </div>
+                    <SectionMessage variant='info' className='wallets-upgrade-modal__disclaimer'>
+                        <Text size='xs' className='wallets-upgrade-modal__disclaimer-message'>
+                            <Localize i18n_default_text='Deriv P2P and Payment Agent services are currently unavailable for Wallets.' />
+                        </Text>
+                    </SectionMessage>
                 </div>
                 <div
                     className={classNames({


### PR DESCRIPTION
## Changes:

Added the banner notifying users regarding having no access to p2p an pa after migrating to wallets

### Screenshots:

![image](https://github.com/user-attachments/assets/58bb4fdd-ef7c-4c6f-9ba1-9d3e287a6c30)

![image](https://github.com/user-attachments/assets/193705b7-03d0-46b0-8530-de8fd89726cf)

