### PR TITLE
[DTRA-V2]/Ahmad/Guide Button quotation fix

### DIFF
--- a/packages/trader/src/AppV2/Components/Guide/Description/ContractDescription/multipliers-trade-description.tsx
+++ b/packages/trader/src/AppV2/Components/Guide/Description/ContractDescription/multipliers-trade-description.tsx
@@ -68,20 +68,20 @@ const MultipliersTradeDescription = ({ onTermClick }: { onTermClick: (term: stri
             type: 'paragraph',
             text: (
                 <Localize
-                    i18n_default_text='Additional features are available to manage your positions: “<0>Take profit</0>”, “<1>Stop loss</1>” and “<2>Deal cancellation</2>” allow you to adjust your level of risk aversion.'
+                    i18n_default_text='Additional features are available to manage your positions: <0>Take profit</0>, <1>Stop loss</1> and <2>Deal cancellation</2> allow you to adjust your level of risk aversion.'
                     components={[
                         <button
-                            className='description__content--definition'
+                            className='description__content--definition quoted-button'
                             key={0}
                             onClick={() => onTermClick(TAKE_PROFIT)}
                         />,
                         <button
-                            className='description__content--definition'
+                            className='description__content--definition quoted-button'
                             key={1}
                             onClick={() => onTermClick(STOP_LOSS)}
                         />,
                         <button
-                            className='description__content--definition'
+                            className='description__content--definition quoted-button'
                             key={2}
                             onClick={() => onTermClick(DEAL_CANCELLATION)}
                         />,

--- a/packages/trader/src/AppV2/Components/Guide/guide.scss
+++ b/packages/trader/src/AppV2/Components/Guide/guide.scss
@@ -133,6 +133,20 @@
     }
 }
 
+.quoted-button {
+    white-space: nowrap;
+    &:before {
+        // for opening quotes
+        content: '\201C';
+        color: var(--component-textIcon-normal-default);
+    }
+    &:after {
+        // for closing quotes
+        content: '\201D';
+        color: var(--component-textIcon-normal-default);
+    }
+}
+
 .definition {
     &__title {
         margin-block-end: var(--component-actionSheet-spacing-padding-lg);


### PR DESCRIPTION
## Changes:

Bug was to show the double quote in same lines as the word it self in multiplier guide description . It is fixed here

### Screenshots:

Please provide some screenshots of the change.
