### PR TITLE
[DTRA-V2]/Ahmad/Draggable Trade Type Scroll fix

### DIFF
--- a/packages/trader/src/AppV2/Components/DraggableList/__tests__/draggable-list.spec.tsx
+++ b/packages/trader/src/AppV2/Components/DraggableList/__tests__/draggable-list.spec.tsx
@@ -39,8 +39,6 @@ describe('DraggableList', () => {
     it('renders categories and items correctly', () => {
         renderComponent();
 
-        expect(screen.getByText('Category 1')).toBeInTheDocument();
-        expect(screen.getByText('Category 2')).toBeInTheDocument();
         expect(screen.getByText('Item 1')).toBeInTheDocument();
         expect(screen.getByText('Item 2')).toBeInTheDocument();
         expect(screen.getByText('Item 3')).toBeInTheDocument();

--- a/packages/trader/src/AppV2/Components/DraggableList/draggable-list.scss
+++ b/packages/trader/src/AppV2/Components/DraggableList/draggable-list.scss
@@ -40,11 +40,14 @@
             margin-bottom: var(--core-spacing-500);
             display: flex;
             justify-content: space-between;
-            padding: 0 var(--core-spacing-600) 0 var(--core-spacing-800);
+            padding: 0 var(--core-spacing-1200) 0 var(--core-spacing-1600);
             &-button {
                 font-size: var(--core-fontSize-75);
                 font-weight: var(--core-fontWeight-bold);
                 line-height: var(--core-lineHeight-200);
+            }
+            &-title {
+                margin-top: 5px;
             }
         }
 

--- a/packages/trader/src/AppV2/Components/DraggableList/draggable-list.scss
+++ b/packages/trader/src/AppV2/Components/DraggableList/draggable-list.scss
@@ -37,17 +37,16 @@
         border-bottom: var(--core-borderWidth-75) solid var(--semantic-color-monochrome-surface-normal-low);
 
         &-header {
-            margin-bottom: var(--core-spacing-500);
             display: flex;
             justify-content: space-between;
-            padding: 0 var(--core-spacing-1200) 0 var(--core-spacing-1600);
+            padding: 0 var(--core-spacing-800) 0 var(--core-spacing-1600);
             &-button {
                 font-size: var(--core-fontSize-75);
                 font-weight: var(--core-fontWeight-bold);
                 line-height: var(--core-lineHeight-200);
             }
             &-title {
-                margin-top: 5px;
+                margin-top: var(--core-spacing-300);
             }
         }
 

--- a/packages/trader/src/AppV2/Components/DraggableList/draggable-list.scss
+++ b/packages/trader/src/AppV2/Components/DraggableList/draggable-list.scss
@@ -42,7 +42,9 @@
             justify-content: space-between;
             padding: 0 var(--core-spacing-600) 0 var(--core-spacing-800);
             &-button {
-                color: var(--component-textIcon-normal-prominent);
+                font-size: var(--core-fontSize-75);
+                font-weight: var(--core-fontWeight-bold);
+                line-height: var(--core-lineHeight-200);
             }
         }
 

--- a/packages/trader/src/AppV2/Components/DraggableList/draggable-list.tsx
+++ b/packages/trader/src/AppV2/Components/DraggableList/draggable-list.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { DragDropContext, Droppable, Draggable, DropResult, DragStart } from 'react-beautiful-dnd';
-import { Text } from '@deriv-com/quill-ui';
 import DraggableListItem from './draggable-list-item';
-import { Localize } from '@deriv/translations';
 
 export type TDraggableListItem = {
     id: string;
@@ -40,7 +38,6 @@ const DraggableList: React.FC<TDraggableListProps> = ({ categories, onRightIconC
     const handleOnDragStart = (start: DragStart) => setDraggedItemId(start.draggableId);
 
     React.useEffect(() => setCategoryList(categories), [categories]);
-
     return (
         <DragDropContext onDragEnd={handleOnDragEnd} onDragStart={handleOnDragStart}>
             {category_list.map(category => (
@@ -63,7 +60,6 @@ const DraggableCategory: React.FC<{
     onAction?: () => void;
 }> = ({ category, draggedItemId, onRightIconClick, onAction }) => (
     <div className='draggable-list-category'>
-        <DraggableCategoryHeader title={category.title} button_title={category.button_title} onAction={onAction} />
         <Droppable droppableId={category.id}>
             {provided => (
                 <div
@@ -80,23 +76,6 @@ const DraggableCategory: React.FC<{
                 </div>
             )}
         </Droppable>
-    </div>
-);
-
-const DraggableCategoryHeader: React.FC<{
-    title?: string;
-    button_title?: string;
-    onAction?: () => void;
-}> = ({ title, button_title, onAction }) => (
-    <div className='draggable-list-category-header'>
-        <Text size='sm' bold className='draggable-list-category-header-title'>
-            {title}
-        </Text>
-        {onAction && (
-            <Text size='sm' bold underlined className='draggable-list-category-header-button' onClick={onAction}>
-                {button_title || <Localize i18n_default_text='Done' />}
-            </Text>
-        )}
     </div>
 );
 

--- a/packages/trader/src/AppV2/Components/TradeTypeList/__tests__/trade-type-list.spec.jsx
+++ b/packages/trader/src/AppV2/Components/TradeTypeList/__tests__/trade-type-list.spec.jsx
@@ -32,8 +32,6 @@ describe('TradeTypeList', () => {
     it('renders categories and items correctly', () => {
         render(<TradeTypeList categories={categories} onRightIconClick={jest.fn()} />);
 
-        expect(screen.getByText('Category 1')).toBeInTheDocument();
-        expect(screen.getByText('Category 2')).toBeInTheDocument();
         expect(screen.getByText('Item 1')).toBeInTheDocument();
         expect(screen.getByText('Item 2')).toBeInTheDocument();
         expect(screen.getByText('Item 3')).toBeInTheDocument();

--- a/packages/trader/src/AppV2/Components/TradeTypeList/trade-type-list.scss
+++ b/packages/trader/src/AppV2/Components/TradeTypeList/trade-type-list.scss
@@ -36,7 +36,6 @@
 
             &-title,
             &-button {
-                color: var(--component-textIcon-normal-prominent);
                 margin-bottom: var(--core-spacing-100);
             }
         }

--- a/packages/trader/src/AppV2/Components/TradeTypeList/trade-type-list.scss
+++ b/packages/trader/src/AppV2/Components/TradeTypeList/trade-type-list.scss
@@ -29,21 +29,6 @@
     &-category {
         padding-bottom: var(--core-spacing-400);
 
-        &-header {
-            display: flex;
-            justify-content: space-between;
-            padding: 0 var(--core-spacing-600) 0 var(--core-spacing-800);
-
-            &-title,
-            &-button {
-                margin-bottom: var(--core-spacing-100);
-            }
-        }
-
-        &__title {
-            font-size: var(--core-fontSize-75);
-        }
-
         &__items {
             margin-top: var(--core-spacing-400);
         }

--- a/packages/trader/src/AppV2/Components/TradeTypeList/trade-type-list.tsx
+++ b/packages/trader/src/AppV2/Components/TradeTypeList/trade-type-list.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import TradeTypeListItem from './trade-type-list-item';
-import { Text } from '@deriv-com/quill-ui';
+import { Button, Text } from '@deriv-com/quill-ui';
 import './trade-type-list.scss';
 import { Localize } from '@deriv/translations';
 import clsx from 'clsx';
@@ -24,8 +24,6 @@ type TTradeTypeListProps = {
     selectable?: boolean;
     onRightIconClick?: (item: TTradeTypeItem) => void;
     onTradeTypeClick?: (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => void;
-    onAction?: () => void;
-    should_show_title?: boolean;
 };
 
 const TradeTypeList: React.FC<TTradeTypeListProps> = ({
@@ -34,8 +32,6 @@ const TradeTypeList: React.FC<TTradeTypeListProps> = ({
     selectable,
     onRightIconClick,
     onTradeTypeClick,
-    onAction,
-    should_show_title = true,
 }) => {
     const [category_list, setCategoryList] = React.useState(categories);
 
@@ -52,22 +48,6 @@ const TradeTypeList: React.FC<TTradeTypeListProps> = ({
                         'trade-type-list-category__border': category.items && category.items.length > 0,
                     })}
                 >
-                    <div className='trade-type-list-category-header'>
-                        <Text size='sm' bold className='trade-type-list-category-header-title'>
-                            {should_show_title && category?.title}
-                        </Text>
-                        {onAction && (
-                            <Text
-                                size='sm'
-                                bold
-                                underlined
-                                className='trade-type-list-category-header-button'
-                                onClick={onAction}
-                            >
-                                {category.button_title || <Localize i18n_default_text='Customise' />}
-                            </Text>
-                        )}
-                    </div>
                     <div className='trade-type-list-category__items'>
                         {category.items?.map((item: TTradeTypeItem) => (
                             <div key={item.id}>

--- a/packages/trader/src/AppV2/Containers/Trade/trade-types.tsx
+++ b/packages/trader/src/AppV2/Containers/Trade/trade-types.tsx
@@ -239,9 +239,33 @@ const TradeTypes = ({ contract_type, onTradeTypeSelect, trade_types, is_dark_mod
             <ActionSheet.Root isOpen={is_open} expandable={false} onClose={handleCloseTradeTypes}>
                 <ActionSheet.Portal shouldCloseOnDrag>
                     <ActionSheet.Header
-                        title={<Localize i18n_default_text='Trade types' />}
+                        title={
+                            <div style={{ margin: '24px 0px' }}>
+                                <Localize i18n_default_text='Trade types' />
+                            </div>
+                        }
                         icon={!is_editing && <Guide />}
                     />
+                    <div>
+                        <div className='draggable-list-category-header'>
+                            <Text size='sm' bold className='draggable-list-category-header-title'>
+                                {is_editing && <Localize i18n_default_text='Pinned' />}
+                            </Text>
+
+                            <Button
+                                color='black'
+                                variant='secondary'
+                                className='draggable-list-category-header-button'
+                                onClick={is_editing ? savePinnedToLocalStorage : handleCustomizeTradeTypes}
+                            >
+                                {is_editing ? (
+                                    <Localize i18n_default_text='Done' />
+                                ) : (
+                                    <Localize i18n_default_text='Customise' />
+                                )}
+                            </Button>
+                        </div>
+                    </div>
                     <ActionSheet.Content className='mock-action-sheet--content'>
                         {is_editing ? (
                             <DraggableList
@@ -253,10 +277,8 @@ const TradeTypes = ({ contract_type, onTradeTypeSelect, trade_types, is_dark_mod
                         ) : (
                             <TradeTypeList
                                 categories={pinned_trade_types}
-                                onAction={handleCustomizeTradeTypes}
                                 onTradeTypeClick={handleOnTradeTypeSelect}
                                 isSelected={id => isTradeTypeSelected(id)}
-                                should_show_title={false}
                                 selectable
                             />
                         )}

--- a/packages/trader/src/AppV2/Containers/Trade/trade-types.tsx
+++ b/packages/trader/src/AppV2/Containers/Trade/trade-types.tsx
@@ -256,7 +256,6 @@ const TradeTypes = ({ contract_type, onTradeTypeSelect, trade_types, is_dark_mod
                             <Text size='sm' bold className='draggable-list-category-header-title'>
                                 {is_editing && <Localize i18n_default_text='Pinned' />}
                             </Text>
-
                             <Button
                                 color='black'
                                 variant='secondary'

--- a/packages/trader/src/AppV2/Containers/Trade/trade-types.tsx
+++ b/packages/trader/src/AppV2/Containers/Trade/trade-types.tsx
@@ -257,7 +257,7 @@ const TradeTypes = ({ contract_type, onTradeTypeSelect, trade_types, is_dark_mod
                                 {is_editing && <Localize i18n_default_text='Pinned' />}
                             </Text>
                             <Button
-                                color='black'
+                                color={is_dark_mode_on ? 'white' : 'black'}
                                 variant='secondary'
                                 className='draggable-list-category-header-button'
                                 onClick={is_editing ? savePinnedToLocalStorage : handleCustomizeTradeTypes}

--- a/packages/trader/src/AppV2/Containers/Trade/trade-types.tsx
+++ b/packages/trader/src/AppV2/Containers/Trade/trade-types.tsx
@@ -236,11 +236,16 @@ const TradeTypes = ({ contract_type, onTradeTypeSelect, trade_types, is_dark_mod
                     </Text>
                 </Button>
             )}
-            <ActionSheet.Root isOpen={is_open} expandable={false} onClose={handleCloseTradeTypes}>
+            <ActionSheet.Root
+                className='trade-types-dialog'
+                isOpen={is_open}
+                expandable={false}
+                onClose={handleCloseTradeTypes}
+            >
                 <ActionSheet.Portal shouldCloseOnDrag>
                     <ActionSheet.Header
                         title={
-                            <div style={{ margin: '24px 0px' }}>
+                            <div className='trade-types-dialog__title'>
                                 <Localize i18n_default_text='Trade types' />
                             </div>
                         }
@@ -266,7 +271,7 @@ const TradeTypes = ({ contract_type, onTradeTypeSelect, trade_types, is_dark_mod
                             </Button>
                         </div>
                     </div>
-                    <ActionSheet.Content className='mock-action-sheet--content'>
+                    <ActionSheet.Content className='trade-types-dialog__content'>
                         {is_editing ? (
                             <DraggableList
                                 categories={pinned_trade_types}

--- a/packages/trader/src/AppV2/Containers/Trade/trade.scss
+++ b/packages/trader/src/AppV2/Containers/Trade/trade.scss
@@ -71,3 +71,11 @@
         }
     }
 }
+.trade-types-dialog {
+    &__title {
+        margin: var(--core-spacing-1200) var(--core-spacing-50);
+    }
+    &__content {
+        padding-top: var(--core-spacing-50);
+    }
+}


### PR DESCRIPTION
## Changes:

In this PR, the "Customize" and "Done" buttons on the "View All Trade Types" and "Draggable Trade Type" pages are now fixed to the header for continuous accessibility. This update eliminates the need to scroll up to click "Done," enhancing usability.

### Screenshots:

Please provide some screenshots of the change.
