### PR TITLE
[BOT]maryia/feat: Implement Survicate Script for In-App Surveys on Deriv Bot

### DIFF
--- a/packages/bot-web-ui/src/app/__tests__/app-main.spec.tsx
+++ b/packages/bot-web-ui/src/app/__tests__/app-main.spec.tsx
@@ -1,3 +1,4 @@
+import { initSurvicate, initSurvicateCalled } from '../../public-path';
 import React from 'react';
 import moment from 'moment';
 import { mockStore } from '@deriv/stores';
@@ -29,7 +30,15 @@ jest.mock('@deriv/deriv-charts', () => ({
 
 jest.mock('@deriv/components', () => ({
     Loading: () => <div>Loading...</div>,
+    initSurvicate: () => <div>script...</div>,
 }));
+
+const mockDOM = `
+  <div id="dbot-survicate">
+    <div id="survicate-box" style="display: block;"></div>
+  </div>
+`;
+document.body.innerHTML = mockDOM;
 
 describe('App', () => {
     //mock for blockly
@@ -49,5 +58,11 @@ describe('App', () => {
             />
         );
         expect(container).toBeInTheDocument();
+    });
+
+    it('check survicate script appended', () => {
+        initSurvicate();
+
+        expect(initSurvicateCalled).toBe(true);
     });
 });

--- a/packages/bot-web-ui/src/app/app-main.tsx
+++ b/packages/bot-web-ui/src/app/app-main.tsx
@@ -1,3 +1,4 @@
+import { initSurvicate } from '../public-path';
 import React from 'react';
 import { TStores } from '@deriv/stores/types';
 import type { TWebSocket } from 'Types';
@@ -18,6 +19,14 @@ const App = ({ passthrough }: TAppProps) => {
         // of dynamic view height(vh) on mobile browsers for few scrollable components
         const vh = window.innerHeight;
         document.body.style.setProperty('--vh', `${vh}px`);
+
+        initSurvicate();
+        return () => {
+            const survicate_box = document.getElementById('survicate-box') || undefined;
+            if (survicate_box) {
+                survicate_box.style.display = 'none';
+            }
+        };
     }, []);
 
     return (

--- a/packages/bot-web-ui/src/app/app-main.tsx
+++ b/packages/bot-web-ui/src/app/app-main.tsx
@@ -22,7 +22,7 @@ const App = ({ passthrough }: TAppProps) => {
 
         initSurvicate();
         return () => {
-            const survicate_box = document.getElementById('survicate-box') || undefined;
+            const survicate_box = document.getElementById('survicate-box');
             if (survicate_box) {
                 survicate_box.style.display = 'none';
             }

--- a/packages/bot-web-ui/src/public-path.ts
+++ b/packages/bot-web-ui/src/public-path.ts
@@ -1,3 +1,5 @@
+import { getLoginId } from '@deriv/bot-skeleton/src/services/api/appId';
+
 const getUrlBase = (path = '') => {
     const l = window.location;
 
@@ -13,5 +15,65 @@ export function setBotPublicPath(path: string) {
 }
 
 export const getImageLocation = (image_name: string) => getUrlBase(`/public/images/common/${image_name}`);
+
+declare global {
+    interface Window {
+        Survicate?: {
+            track: (attribute: string, value: string) => void;
+        };
+    }
+}
+
+const setSurvicateUserAttributes = (country: string, type: string, creationDate: string) => {
+    if (window.Survicate) {
+        if (country) window.Survicate.track('userCountry', country);
+        if (type) window.Survicate.track('accountType', type);
+        if (creationDate) window.Survicate.track('accountCreationDate', creationDate);
+    }
+};
+
+// eslint-disable-next-line import/no-mutable-exports
+let initSurvicateCalled = false;
+
+const loadSurvicateScript = (callback: () => void) => {
+    const script = document.createElement('script');
+    script.id = 'dbot-survicate';
+    script.async = true;
+    script.src = 'https://survey.survicate.com/workspaces/83b651f6b3eca1ab4551d95760fe5deb/web_surveys.js';
+    script.onload = callback;
+
+    const firstScript = document.getElementsByTagName('script')[0];
+    if (firstScript?.parentNode) {
+        firstScript.parentNode.insertBefore(script, firstScript);
+    } else {
+        document.body.appendChild(script);
+    }
+};
+
+const initSurvicate = () => {
+    if (initSurvicateCalled) return;
+    initSurvicateCalled = true;
+    const active_loginid = getLoginId();
+    const client_accounts = JSON.parse(localStorage.getItem('client.accounts') as string) || undefined;
+
+    const setAttributesIfAvailable = () => {
+        if (active_loginid && client_accounts) {
+            const { residence, account_type, created_at } = client_accounts[active_loginid] || {};
+            setSurvicateUserAttributes(residence, account_type, created_at);
+        }
+    };
+
+    if (document.getElementById('dbot-survicate')) {
+        const survicateBox = document.getElementById('survicate-box');
+        if (survicateBox) {
+            survicateBox.style.display = 'block';
+        }
+        setAttributesIfAvailable();
+    } else {
+        loadSurvicateScript(setAttributesIfAvailable);
+    }
+};
+
+export { initSurvicate, initSurvicateCalled };
 
 setBotPublicPath(getUrlBase('/'));


### PR DESCRIPTION
## Changes:

- Add **Survicate tracking script** to Deriv Bot so that we can conduct monthly **Customer Satisfaction Score (CSAT)** and **Customer Effort Score (CES) surveys** and collect more responses than **Hotjar** allows
- Survicate will help us gather CSAT and CES metrics with a higher response rate
- Survicate allows us to capture user metadata such as user’s **country of residence**, **account type**, and **account creation date**, which will help us personalize and segment survey results for more in-depth analysis.
=> Passed user attributes:

- [x] 1. Users' country of residence
- [x] 2. Account type
- [x] 3. User account creation date

### Screenshots:

Please provide some screenshots of the change.
