### PR TITLE
[UPM-1689] Suisin/chore: show 1 attempt left error message

### DIFF
--- a/packages/shared/src/utils/constants/phone-number-verification.tsx
+++ b/packages/shared/src/utils/constants/phone-number-verification.tsx
@@ -58,11 +58,14 @@ export const getUseRequestPhoneNumberOTPErrorMessage = (
     }
 };
 
-export const phoneOTPErrorMessage = (error_code: string) => {
+export const phoneOTPErrorMessage = (error_code: string, verify_attempts_remaining: number) => {
     switch (error_code) {
         case 'PhoneCodeExpired':
             return <Localize i18n_default_text='Code expired. Get a new one.' />;
         case 'InvalidOTP':
+            if (verify_attempts_remaining - 1 === 1) {
+                return <Localize i18n_default_text='Try again. You have 1 attempt left.' />;
+            }
             return <Localize i18n_default_text='Invalid code. Try again.' />;
         default:
             break;
@@ -72,12 +75,16 @@ export const phoneOTPErrorMessage = (error_code: string) => {
 export const emailOTPErrorMessage = (
     error_code: string,
     getCurrentCarrier: () => string,
-    getOtherCarrier: () => string
+    getOtherCarrier: () => string,
+    challenge_attempts_remaining: number
 ) => {
     switch (error_code) {
         case 'EmailCodeExpired':
             return <Localize i18n_default_text='Code expired. Get a new code.' />;
         case 'InvalidToken':
+            if (challenge_attempts_remaining - 1 === 1) {
+                return <Localize i18n_default_text='Try again. You have 1 attempt left.' />;
+            }
             return <Localize i18n_default_text='Invalid code. Try again or get a new code.' />;
         case 'PhoneNumberVerificationSuspended':
             return (


### PR DESCRIPTION
## Changes:

Show 1 attempt left for users in error message on otp screens.

### Screenshots:
![Screenshot 2024-11-01 at 7 12 28 PM](https://github.com/user-attachments/assets/667bbe55-4c7b-4a33-9ce2-109ffa93b9b2)
![Screenshot 2024-11-01 at 7 12 59 PM](https://github.com/user-attachments/assets/d1b4c8d3-67b5-4782-b7eb-e3f5a75f2a53)
