### PR TITLE
Update deriv-charts to 2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "@deriv-com/utils": "^0.0.36",
                 "@deriv/api-types": "1.0.172",
                 "@deriv/deriv-api": "^1.0.15",
-                "@deriv/deriv-charts": "^2.5.1",
+                "@deriv/deriv-charts": "^2.6.1",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/quill-design": "^1.3.2",
                 "@deriv/quill-icons": "1.23.3",
@@ -3547,9 +3547,9 @@
             }
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.5.1.tgz",
-            "integrity": "sha512-CDyh1uQS2plp2EkGWOx0UYSWck8iqKgU1B9mFe0YrjHEqfz7WqwW4zyKqgojAMdEWzStbNMv5J811saB8Zmt8w==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-2.6.1.tgz",
+            "integrity": "sha512-FCP4clUfFP7gFOcPK8ZmOHn4zmgj9B0dHYI4jPT4Ltn7U6VXr43UqAfO8cVs0I4OWDbrO3Ozt3cCjzu4X4ajGA==",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",
                 "@welldone-software/why-did-you-render": "^3.3.8",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -77,7 +77,7 @@
         "@deriv/api-types": "1.0.172",
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "^2.5.1",
+        "@deriv/deriv-charts": "^2.6.1",
         "@deriv/hooks": "^1.0.0",
         "@deriv/quill-icons": "1.23.3",
         "@deriv/shared": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -109,7 +109,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.5.1",
+        "@deriv/deriv-charts": "^2.6.1",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/quill-design": "^1.3.2",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -96,7 +96,7 @@
         "@deriv/api-types": "1.0.172",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.15",
-        "@deriv/deriv-charts": "^2.5.1",
+        "@deriv/deriv-charts": "^2.6.1",
         "@deriv/hooks": "^1.0.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",


### PR DESCRIPTION
This PR updates @deriv/deriv-charts to 2.6.1