### PR TITLE
Rupato/BOT-2020/fix: blockly delete block translations

### DIFF
--- a/packages/bot-skeleton/src/scratch/blockly.js
+++ b/packages/bot-skeleton/src/scratch/blockly.js
@@ -18,7 +18,7 @@ const modifyBlocklyWorkSpaceContextMenu = () => {
         cleanWorkspace: localize('Clean up Blocks'),
         collapseWorkspace: localize('Collapse Blocks'),
         expandWorkspace: localize('Expand Blocks'),
-        workspaceDelete: localize('Delete All Block'),
+        workspaceDelete: localize('Delete All BlockS'),
     };
 
     Object.keys(items_to_localize).forEach(item_id => {

--- a/packages/bot-skeleton/src/scratch/blockly.js
+++ b/packages/bot-skeleton/src/scratch/blockly.js
@@ -18,7 +18,7 @@ const modifyBlocklyWorkSpaceContextMenu = () => {
         cleanWorkspace: localize('Clean up Blocks'),
         collapseWorkspace: localize('Collapse Blocks'),
         expandWorkspace: localize('Expand Blocks'),
-        workspaceDelete: localize('Delete All BlockS'),
+        workspaceDelete: localize('Delete All Blocks'),
     };
 
     Object.keys(items_to_localize).forEach(item_id => {

--- a/packages/bot-skeleton/src/scratch/blockly.js
+++ b/packages/bot-skeleton/src/scratch/blockly.js
@@ -18,6 +18,7 @@ const modifyBlocklyWorkSpaceContextMenu = () => {
         cleanWorkspace: localize('Clean up Blocks'),
         collapseWorkspace: localize('Collapse Blocks'),
         expandWorkspace: localize('Expand Blocks'),
+        workspaceDelete: localize('Delete All Block'),
     };
 
     Object.keys(items_to_localize).forEach(item_id => {

--- a/packages/bot-skeleton/src/scratch/utils/index.js
+++ b/packages/bot-skeleton/src/scratch/utils/index.js
@@ -681,7 +681,7 @@ const all_context_menu_options = [
     localize('Download Block'),
 ];
 
-const deleteBlocksLocaleText = localize('Delete Blocks');
+const deleteBlocksLocaleText = localize('Delete Block');
 const deleteAllBlocksLocaleText = localize('Delete All Blocks');
 
 export const modifyContextMenu = (menu, add_new_items = []) => {
@@ -696,10 +696,12 @@ export const modifyContextMenu = (menu, add_new_items = []) => {
 
     for (let i = 0; i < menu.length; i++) {
         const menu_text = menu[i].text.toLowerCase();
-        if (menu_text.includes('block') && !menu_text.includes('blocks')) {
-            menu[i].text = deleteBlocksLocaleText;
-        } else if (menu_text.includes('blocks')) {
-            menu[i].text = deleteAllBlocksLocaleText;
+        if (menu_text.includes('delete')) {
+            if (menu_text.includes('block') && !menu_text.includes('blocks')) {
+                menu[i].text = deleteBlocksLocaleText;
+            } else {
+                menu[i].text = deleteAllBlocksLocaleText;
+            }
         } else {
             const localized_text = localize(menu[i].text);
             if (all_context_menu_options.includes(localized_text)) {

--- a/packages/bot-skeleton/src/scratch/utils/index.js
+++ b/packages/bot-skeleton/src/scratch/utils/index.js
@@ -681,11 +681,8 @@ const all_context_menu_options = [
     localize('Download Block'),
 ];
 
-// Need for later
-// const deleteLocaleText = localize("Delete");
-// const blocksLocaleText = localize("Blocks");
-// const deleteBlocksLocaleText = localize("Delete Blocks");
-// const deleteBlocksLocalePattern = new RegExp(`^${deleteLocaleText} \\d+ ${blocksLocaleText}$`);
+const deleteBlocksLocaleText = localize('Delete Blocks');
+const deleteAllBlocksLocaleText = localize('Delete All Blocks');
 
 export const modifyContextMenu = (menu, add_new_items = []) => {
     const include_items = [...common_included_items, ...add_new_items];
@@ -698,9 +695,16 @@ export const modifyContextMenu = (menu, add_new_items = []) => {
     });
 
     for (let i = 0; i < menu.length; i++) {
-        const localized_text = localize(menu[i].text);
-        if (all_context_menu_options.includes(localized_text)) {
-            menu[i].text = localized_text;
+        const menu_text = menu[i].text.toLowerCase();
+        if (menu_text.includes('block') && !menu_text.includes('blocks')) {
+            menu[i].text = deleteBlocksLocaleText;
+        } else if (menu_text.includes('blocks')) {
+            menu[i].text = deleteAllBlocksLocaleText;
+        } else {
+            const localized_text = localize(menu[i].text);
+            if (all_context_menu_options.includes(localized_text)) {
+                menu[i].text = localized_text;
+            }
         }
     }
 };


### PR DESCRIPTION
Fixed the blockly translations on the context menu
![image](https://github.com/user-attachments/assets/88233977-2b5a-40e3-8f5e-fa95b0096d78)
![Screenshot 2024-11-07 at 1 49 42 PM](https://github.com/user-attachments/assets/374f3607-b56e-4ea0-b648-d5d1787c7752)
