### PR TITLE
fix: disable enable on accumulator block

### DIFF
--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/accumulator_take_profit.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/accumulator_take_profit.js
@@ -1,7 +1,7 @@
 import { localize } from '@deriv/translations';
 import { getCurrencyDisplayCode } from '@deriv/shared';
 import { config } from '../../../../constants/config';
-import { modifyContextMenu } from '../../../utils';
+import { excludeOptionFromContextMenu, modifyContextMenu } from '../../../utils';
 
 const description = localize(
     'Your contract is closed automatically when your profit is more than or equals to this amount. This block can only be used with the accumulator trade type.'
@@ -56,6 +56,8 @@ Blockly.Blocks.accumulator_take_profit = {
         }
     },
     customContextMenu(menu) {
+        const menu_items = [localize('Enable Block'), localize('Disable Block')];
+        excludeOptionFromContextMenu(menu, menu_items);
         modifyContextMenu(menu);
     },
     restricted_parents: ['trade_definition_accumulator'],


### PR DESCRIPTION
Remove disable enable feature on the accumulator take profit block.

![image](https://github.com/user-attachments/assets/022cf61d-817d-49f1-862e-d67d79534bc3)
