### PR TITLE
Akmal / fix: default to correct trade type when allow equals is enabled

### DIFF
--- a/packages/trader/src/Stores/Modules/Trading/trade-store.ts
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.ts
@@ -622,7 +622,7 @@ export default class TradeStore extends BaseStore {
         reaction(
             () => this.is_equal,
             () => {
-                this.onAllowEqualsChange();
+                this.contract_type?.includes(TRADE_TYPES.RISE_FALL) && this.onAllowEqualsChange();
             }
         );
         reaction(


### PR DESCRIPTION
## Changes:

This fix ensures that the correct trade type is selected by default when the "allow equals" option is enabled, improving trade setup consistency.

1. Default Trade Selection: Automatically select the appropriate trade type by default when "allow equals" is activated, avoiding incorrect configurations.
2. Consistent Behavior: Maintain consistent behavior across trade types, ensuring the right defaults are applied based on settings.
3. User Experience: Simplify setup by auto-selecting compatible trade types, reducing user intervention and setup errors.

This fix enhances user experience and consistency by ensuring the correct trade type is pre-selected with "allow equals" enabled.

<img width="468" alt="image" src="https://github.com/user-attachments/assets/bc0096e5-8d46-4e21-b073-214e52850669">

