### PR TITLE
[WALL] Lubega / WALL-5049 / Enter existing mt5 password modal

### DIFF
--- a/packages/wallets/src/components/Base/WalletPasswordField/WalletPasswordField.tsx
+++ b/packages/wallets/src/components/Base/WalletPasswordField/WalletPasswordField.tsx
@@ -98,12 +98,12 @@ const WalletPasswordField: React.FC<WalletPasswordFieldProps> = ({
     }, [isTouched]);
 
     useEffect(() => {
-        if (!hideValidation) {
-            setShowErrorMessage(!!passwordError);
-            setErrorMessage(passwordError ? getPasswordErrorMessage(localize).PasswordError : validationErrorMessage);
-        } else {
+        if (hideValidation) {
             setShowErrorMessage(!!passwordError);
             setErrorMessage(passwordError ? getPasswordErrorMessage(localize).PasswordError : '');
+        } else {
+            setShowErrorMessage(!!passwordError);
+            setErrorMessage(passwordError ? getPasswordErrorMessage(localize).PasswordError : validationErrorMessage);
         }
     }, [passwordError, validationErrorMessage, localize, hideValidation]);
 
@@ -115,7 +115,7 @@ const WalletPasswordField: React.FC<WalletPasswordFieldProps> = ({
                 isInvalid={
                     hideValidation
                         ? !!passwordError
-                        : (passwordValidation && isTouched) || showErrorMessage || !!passwordError || false
+                        : (passwordValidation && isTouched) || showErrorMessage || !!passwordError
                 }
                 label={label}
                 messageVariant={!hideValidation && validationErrorMessage ? 'warning' : undefined}

--- a/packages/wallets/src/components/Base/WalletPasswordFieldLazy/WalletPasswordFieldLazy.tsx
+++ b/packages/wallets/src/components/Base/WalletPasswordFieldLazy/WalletPasswordFieldLazy.tsx
@@ -3,7 +3,7 @@ import { Loader } from '@deriv-com/ui';
 import { WalletTextFieldProps } from '../WalletTextField/WalletTextField';
 
 export interface WalletPasswordFieldProps extends WalletTextFieldProps {
-    hideValidation?: boolean;
+    hideWarning?: boolean;
     mt5Policy?: boolean; // This prop is used to utilize the new password validation for MT5.
     password: string;
     passwordError?: boolean;

--- a/packages/wallets/src/components/Base/WalletPasswordFieldLazy/WalletPasswordFieldLazy.tsx
+++ b/packages/wallets/src/components/Base/WalletPasswordFieldLazy/WalletPasswordFieldLazy.tsx
@@ -3,6 +3,7 @@ import { Loader } from '@deriv-com/ui';
 import { WalletTextFieldProps } from '../WalletTextField/WalletTextField';
 
 export interface WalletPasswordFieldProps extends WalletTextFieldProps {
+    hideValidation?: boolean;
     mt5Policy?: boolean; // This prop is used to utilize the new password validation for MT5.
     password: string;
     passwordError?: boolean;

--- a/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModalFooters.tsx
+++ b/packages/wallets/src/features/cfd/modals/MT5PasswordModal/MT5PasswordModalFooters.tsx
@@ -25,7 +25,7 @@ export const MT5PasswordModalFooter = ({ disabled, isLoading, onPrimaryClick, on
                 textSize='sm'
                 variant='outlined'
             >
-                <Localize i18n_default_text='Forgot password?' />
+                <Localize i18n_default_text='Forgot password' />
             </Button>
             <Button
                 disabled={disabled}

--- a/packages/wallets/src/features/cfd/modals/MT5PasswordModal/__tests__/MT5PasswordModal.spec.tsx
+++ b/packages/wallets/src/features/cfd/modals/MT5PasswordModal/__tests__/MT5PasswordModal.spec.tsx
@@ -231,7 +231,7 @@ describe('MT5PasswordModal', () => {
 
         expect(screen.getByText('EnterPassword')).toBeInTheDocument();
         expect(screen.getByText('MT5PasswordModalFooter')).toBeInTheDocument();
-        expect(screen.getByText('Enter your Deriv MT5 password')).toBeInTheDocument();
+        expect(screen.getByText('Add an MT5 Standard account')).toBeInTheDocument();
     });
 
     it('renders default content for demo account', () => {
@@ -242,7 +242,7 @@ describe('MT5PasswordModal', () => {
 
         expect(screen.getByText('EnterPassword')).toBeInTheDocument();
         expect(screen.getByText('MT5PasswordModalFooter')).toBeInTheDocument();
-        expect(screen.getByText('Enter your demo Deriv MT5 password')).toBeInTheDocument();
+        expect(screen.getByText('Add an MT5 Standard demo account')).toBeInTheDocument();
     });
 
     it('renders WalletError for account creation errors', () => {
@@ -255,6 +255,20 @@ describe('MT5PasswordModal', () => {
         render(<MT5PasswordModal account={mockAccount} />);
 
         expect(screen.getByText('WalletError')).toBeInTheDocument();
+    });
+
+    it('returns null when createMT5AccountError is undefined', () => {
+        (useCreateMT5Account as jest.Mock).mockReturnValue({
+            error: undefined,
+            status: 'error',
+        });
+
+        const { container } = render(
+            //@ts-expect-error since this is a mock, we only need partial properties of the account
+            <MT5PasswordModal account={mockAccount} />
+        );
+
+        expect(container).toBeEmptyDOMElement();
     });
 
     it('renders WalletError when email verification fails', () => {

--- a/packages/wallets/src/features/cfd/modals/MT5PasswordModal/__tests__/MT5PasswordModal.spec.tsx
+++ b/packages/wallets/src/features/cfd/modals/MT5PasswordModal/__tests__/MT5PasswordModal.spec.tsx
@@ -257,20 +257,6 @@ describe('MT5PasswordModal', () => {
         expect(screen.getByText('WalletError')).toBeInTheDocument();
     });
 
-    it('returns null when createMT5AccountError is undefined', () => {
-        (useCreateMT5Account as jest.Mock).mockReturnValue({
-            error: undefined,
-            status: 'error',
-        });
-
-        const { container } = render(
-            //@ts-expect-error since this is a mock, we only need partial properties of the account
-            <MT5PasswordModal account={mockAccount} />
-        );
-
-        expect(container).toBeEmptyDOMElement();
-    });
-
     it('renders WalletError when email verification fails', () => {
         (useVerifyEmail as jest.Mock).mockReturnValue({
             error: { error: { message: 'Error' } },

--- a/packages/wallets/src/features/cfd/modals/MT5PasswordModal/__tests__/MT5PasswordModalFooters.spec.tsx
+++ b/packages/wallets/src/features/cfd/modals/MT5PasswordModal/__tests__/MT5PasswordModalFooters.spec.tsx
@@ -21,7 +21,7 @@ describe('MT5PasswordModalFooter', () => {
                 onSecondaryClick={jest.fn()}
             />
         );
-        expect(screen.getByText('Forgot password?')).toBeInTheDocument();
+        expect(screen.getByText('Forgot password')).toBeInTheDocument();
         expect(screen.getByText('Add account')).toBeInTheDocument();
     });
 
@@ -37,7 +37,7 @@ describe('MT5PasswordModalFooter', () => {
                 onSecondaryClick={mockSecondaryClick}
             />
         );
-        await userEvent.click(screen.getByText('Forgot password?'));
+        await userEvent.click(screen.getByText('Forgot password'));
         expect(mockSecondaryClick).toHaveBeenCalled();
     });
 

--- a/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
+++ b/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
@@ -4,7 +4,6 @@ import { Localize, useTranslations } from '@deriv-com/translations';
 import { Button, Text, useDevice } from '@deriv-com/ui';
 import { WalletPasswordFieldLazy } from '../../../../components/Base';
 import { THooks, TMarketTypes, TPlatforms } from '../../../../types';
-import { validPassword, validPasswordMT5 } from '../../../../utils/password-validation';
 import { CFD_PLATFORMS, getMarketTypeDetails, JURISDICTION, PlatformDetails } from '../../constants';
 import { TAvailableMT5Account } from '../../types';
 import { MT5LicenceMessage, MT5PasswordModalTnc } from '../components';
@@ -52,8 +51,6 @@ const EnterPassword: React.FC<TProps> = ({
     const { localize } = useTranslations();
     const { data } = useActiveWalletAccount();
 
-    const isMT5 = platform === CFD_PLATFORMS.MT5;
-    const disableButton = isMT5 ? !validPasswordMT5(password) : !validPassword(password);
     const accountType = data?.is_virtual ? localize('Demo') : localize('Real');
     const title = PlatformDetails[platform].title;
     const marketTypeTitle =
@@ -81,18 +78,18 @@ const EnterPassword: React.FC<TProps> = ({
             <div className='wallets-enter-password__content'>
                 <Text align='start' className='wallets-enter-password__description' size={isDesktop ? 'sm' : 'md'}>
                     <Localize
-                        i18n_default_text='Enter your {{title}} password to add a {{accountTitle}} {{marketTypeTitle}} account'
+                        i18n_default_text='Enter your {{title}} password to add an {{accountTitle}} {{marketTypeTitle}} account'
                         values={{
-                            accountTitle:
-                                platform === CFD_PLATFORMS.MT5 && accountType === 'Demo'
-                                    ? `${accountType.toLocaleLowerCase()} ${CFD_PLATFORMS.MT5.toLocaleUpperCase()}`
-                                    : title,
-                            marketTypeTitle,
+                            accountTitle: CFD_PLATFORMS.MT5.toLocaleUpperCase(),
+                            marketTypeTitle: isVirtual
+                                ? `${marketTypeTitle} ${accountType.toLocaleLowerCase()}`
+                                : marketTypeTitle,
                             title,
                         }}
                     />
                 </Text>
                 <WalletPasswordFieldLazy
+                    hideValidation
                     label={localize('{{title}} password', { title })}
                     onChange={onPasswordChange}
                     password={password}
@@ -119,10 +116,10 @@ const EnterPassword: React.FC<TProps> = ({
                         textSize='sm'
                         variant='outlined'
                     >
-                        <Localize i18n_default_text='Forgot password?' />
+                        <Localize i18n_default_text='Forgot password' />
                     </Button>
                     <Button
-                        disabled={!password || isLoading || disableButton || !isTncChecked}
+                        disabled={!password || isLoading || !isTncChecked}
                         isLoading={isLoading}
                         onClick={onPrimaryClick}
                         size='lg'

--- a/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
+++ b/packages/wallets/src/features/cfd/screens/EnterPassword/EnterPassword.tsx
@@ -3,7 +3,10 @@ import { useActiveWalletAccount } from '@deriv/api-v2';
 import { Localize, useTranslations } from '@deriv-com/translations';
 import { Button, Text, useDevice } from '@deriv-com/ui';
 import { WalletPasswordFieldLazy } from '../../../../components/Base';
+import { validatePassword } from '../../../../components/Base/WalletPasswordField/WalletPasswordField';
+import { getPasswordErrorMessage } from '../../../../constants/password';
 import { THooks, TMarketTypes, TPlatforms } from '../../../../types';
+import { validPassword, validPasswordMT5 } from '../../../../utils/password-validation';
 import { CFD_PLATFORMS, getMarketTypeDetails, JURISDICTION, PlatformDetails } from '../../constants';
 import { TAvailableMT5Account } from '../../types';
 import { MT5LicenceMessage, MT5PasswordModalTnc } from '../components';
@@ -51,6 +54,12 @@ const EnterPassword: React.FC<TProps> = ({
     const { localize } = useTranslations();
     const { data } = useActiveWalletAccount();
 
+    const isMT5 = platform === CFD_PLATFORMS.MT5;
+    const { validationErrorMessage } = validatePassword(password, isMT5, localize);
+    const disableButton = isMT5
+        ? !validPasswordMT5(password) &&
+          validationErrorMessage !== getPasswordErrorMessage(localize).missingCharacterMT5
+        : !validPassword(password);
     const accountType = data?.is_virtual ? localize('Demo') : localize('Real');
     const title = PlatformDetails[platform].title;
     const marketTypeTitle =
@@ -77,19 +86,31 @@ const EnterPassword: React.FC<TProps> = ({
             )}
             <div className='wallets-enter-password__content'>
                 <Text align='start' className='wallets-enter-password__description' size={isDesktop ? 'sm' : 'md'}>
-                    <Localize
-                        i18n_default_text='Enter your {{title}} password to add an {{accountTitle}} {{marketTypeTitle}} account'
-                        values={{
-                            accountTitle: CFD_PLATFORMS.MT5.toLocaleUpperCase(),
-                            marketTypeTitle: isVirtual
-                                ? `${marketTypeTitle} ${accountType.toLocaleLowerCase()}`
-                                : marketTypeTitle,
-                            title,
-                        }}
-                    />
+                    {isMT5 ? (
+                        <Localize
+                            i18n_default_text='Enter your {{title}} password to add an {{accountTitle}} {{marketTypeTitle}} account'
+                            values={{
+                                accountTitle: CFD_PLATFORMS.MT5.toLocaleUpperCase(),
+                                marketTypeTitle: isVirtual
+                                    ? `${marketTypeTitle} ${accountType.toLocaleLowerCase()}`
+                                    : marketTypeTitle,
+                                title,
+                            }}
+                        />
+                    ) : (
+                        <Localize
+                            i18n_default_text='Enter your {{title}} password to add a {{title}} {{marketTypeTitle}} account'
+                            values={{
+                                marketTypeTitle: isVirtual
+                                    ? `${marketTypeTitle} ${accountType.toLocaleLowerCase()}`
+                                    : marketTypeTitle,
+                                title,
+                            }}
+                        />
+                    )}
                 </Text>
                 <WalletPasswordFieldLazy
-                    hideValidation
+                    hideWarning
                     label={localize('{{title}} password', { title })}
                     onChange={onPasswordChange}
                     password={password}
@@ -119,7 +140,7 @@ const EnterPassword: React.FC<TProps> = ({
                         <Localize i18n_default_text='Forgot password' />
                     </Button>
                     <Button
-                        disabled={!password || isLoading || !isTncChecked}
+                        disabled={!password || isLoading || disableButton || !isTncChecked}
                         isLoading={isLoading}
                         onClick={onPrimaryClick}
                         size='lg'

--- a/packages/wallets/src/features/cfd/screens/EnterPassword/__test__/EnterPassword.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/EnterPassword/__test__/EnterPassword.spec.tsx
@@ -30,6 +30,7 @@ describe('EnterPassword', () => {
     });
 
     const title = `Enter your ${PlatformDetails.mt5.title} password`;
+    const shortPassword = 'abcd';
     const validPassword = 'Abcd1234!';
 
     const defaultProps = {
@@ -78,6 +79,12 @@ describe('EnterPassword', () => {
         const addAccountButton = screen.getByRole('button', { name: 'Add account' });
         await userEvent.click(addAccountButton);
         expect(defaultProps.onPrimaryClick).toHaveBeenCalled();
+    });
+
+    it('disables the "Add account" button when password is invalid', () => {
+        renderComponent({ password: shortPassword });
+        const addAccountButton = screen.getByRole('button', { name: 'Add account' });
+        expect(addAccountButton).toBeDisabled();
     });
 
     it('disables the "Add account" button when tnc is not checked', () => {

--- a/packages/wallets/src/features/cfd/screens/EnterPassword/__test__/EnterPassword.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/EnterPassword/__test__/EnterPassword.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useActiveWalletAccount } from '@deriv/api-v2';
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MARKET_TYPE, PlatformDetails } from '../../../constants';
 import EnterPassword from '../EnterPassword';
@@ -10,7 +10,12 @@ jest.mock('@deriv/api-v2');
 jest.mock('../../components', () => ({
     ...jest.requireActual('../../components'),
     MT5LicenceMessage: jest.fn(() => <div>MT5LicenceMessage</div>),
-    MT5PasswordModalTnc: jest.fn(() => <div>MT5PasswordModalTnc</div>),
+    MT5PasswordModalTnc: ({ onChange }: { onChange: () => void }) => (
+        <div>
+            <input data-testid='dt_mt5_password_modal_tnc' onChange={() => onChange()} type='checkbox' />
+            MT5PasswordModalTnc
+        </div>
+    ),
 }));
 
 describe('EnterPassword', () => {
@@ -20,10 +25,11 @@ describe('EnterPassword', () => {
         mockUseActiveWalletAccount.mockReturnValue({ data: { is_virtual: false } });
     });
 
-    afterEach(cleanup);
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
 
     const title = `Enter your ${PlatformDetails.mt5.title} password`;
-    const shortPassword = 'abcd';
     const validPassword = 'Abcd1234!';
 
     const defaultProps = {
@@ -34,6 +40,7 @@ describe('EnterPassword', () => {
         onPasswordChange: jest.fn(),
         onPrimaryClick: jest.fn(),
         onSecondaryClick: jest.fn(),
+        onTncChange: jest.fn(),
         password: '',
         passwordError: false,
         platform: PlatformDetails.mt5.platform,
@@ -41,25 +48,14 @@ describe('EnterPassword', () => {
     };
 
     const renderComponent = (props = {}) => {
-        return render(
-            <EnterPassword
-                isTncChecked={true}
-                onTncChange={function (): void {
-                    throw new Error('Function not implemented.');
-                }}
-                {...defaultProps}
-                {...props}
-            />
-        );
+        return render(<EnterPassword {...defaultProps} {...props} />);
     };
 
     it('renders the component correctly', () => {
         renderComponent();
         expect(screen.getByText(title)).toBeInTheDocument();
         expect(
-            screen.getByText(
-                `Enter your ${PlatformDetails.mt5.title} password to add a ${PlatformDetails.mt5.title} Financial account`
-            )
+            screen.getByText(`Enter your ${PlatformDetails.mt5.title} password to add an MT5 Financial account`)
         ).toBeInTheDocument();
     });
 
@@ -70,9 +66,9 @@ describe('EnterPassword', () => {
         expect(defaultProps.onPasswordChange).toHaveBeenCalled();
     });
 
-    it('calls onSecondaryClick when clicking the "Forgot password?" button', async () => {
+    it('calls onSecondaryClick when clicking the "Forgot password" button', async () => {
         renderComponent();
-        const forgotPasswordButton = screen.getByRole('button', { name: 'Forgot password?' });
+        const forgotPasswordButton = screen.getByRole('button', { name: 'Forgot password' });
         await userEvent.click(forgotPasswordButton);
         expect(defaultProps.onSecondaryClick).toHaveBeenCalled();
     });
@@ -82,12 +78,6 @@ describe('EnterPassword', () => {
         const addAccountButton = screen.getByRole('button', { name: 'Add account' });
         await userEvent.click(addAccountButton);
         expect(defaultProps.onPrimaryClick).toHaveBeenCalled();
-    });
-
-    it('disables the "Add account" button when password is invalid', () => {
-        renderComponent({ password: shortPassword });
-        const addAccountButton = screen.getByRole('button', { name: 'Add account' });
-        expect(addAccountButton).toBeDisabled();
     });
 
     it('disables the "Add account" button when tnc is not checked', () => {
@@ -122,6 +112,13 @@ describe('EnterPassword', () => {
         renderComponent({ account: { shortcode: 'bvi' } });
 
         expect(screen.getByText('MT5PasswordModalTnc')).toBeInTheDocument();
+    });
+
+    it('calls onTncChange when checking the tnc checkbox', async () => {
+        renderComponent({ account: { shortcode: 'bvi' } });
+        const tncCheckbox = screen.getByTestId('dt_mt5_password_modal_tnc');
+        await userEvent.click(tncCheckbox);
+        expect(defaultProps.onTncChange).toHaveBeenCalled();
     });
 
     it('hides the mt5 tnc checkbox for non-regulated real accounts', () => {


### PR DESCRIPTION
## Changes:

- [x] Fix title, description and CTA content for MT5 enter password modal in desktop and responsive
- [x] Fix button disabling logic for CTA
- [x] Fix validation for enter password modal to not check for warning message
- [x] Fix unit test with updated logic

### Screenshots:
<img width="1234" alt="Bildschirmfoto 2024-11-14 um 2 27 39 PM" src="https://github.com/user-attachments/assets/4bcfb57c-e9a0-4b67-9a78-6e3632476443">

<img width="1234" alt="Bildschirmfoto 2024-11-14 um 2 27 57 PM" src="https://github.com/user-attachments/assets/cc10f18a-ad35-49ba-adf1-860b94d43c50">

### Recording:

https://github.com/user-attachments/assets/7a1313bc-f4d0-4a64-ae2c-758bdf59106f

### Password change modal behaviour:

https://github.com/user-attachments/assets/f2e8f7f1-88d6-4c8d-b9e3-1c1ca6956159





