### PR TITLE
Jim/update action organisation

### DIFF
--- a/.github/workflows/generate_app_id.yml
+++ b/.github/workflows/generate_app_id.yml
@@ -19,7 +19,7 @@ jobs:
         steps:
             - name: Capture Vercel preview URL
               id: vercel_preview_url
-              uses: binary-com/vercel-preview-url-action@v1.0.5
+              uses: deriv-com/vercel-preview-url-action@v1.0.5
               with:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   preview_url_regexp: \[Visit Preview\]\((.*?.sx)\)

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Capture Vercel preview URL
         id: vercel_preview_url
-        uses: binary-com/vercel-preview-url-action@v1.0.5
+        uses: deriv-com/vercel-preview-url-action@v1.0.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           preview_url_regexp: \[Visit Preview\]\((.*?.sx)\)

--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - name: Capture Vercel preview URL
       id: vercel_preview_url
-      uses: binary-com/vercel-preview-url-action@v1.0.5
+      uses: deriv-com/vercel-preview-url-action@v1.0.5
       with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           


### PR DESCRIPTION
## Changes:

After migrating [this](https://github.com/deriv-com/vercel-preview-url-action) repository from `binary-com` to `deriv-com`, we need to update the usages inside of `deriv-app`