### PR TITLE
[WALL] Lubega / WALL-5054 / MT5 demo create success modal content

### DIFF
--- a/packages/wallets/src/features/cfd/modals/CTraderSuccessModal/CTraderSuccessModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/CTraderSuccessModal/CTraderSuccessModal.tsx
@@ -27,7 +27,7 @@ const CTraderSuccessModal = ({ createdAccount, isDemo, walletCurrencyType }: TCT
     if (isLoading) return <Loader />;
 
     const description = isDemo
-        ? localize("Let's practise trading with {{ctraderBalance}} virtual funds.", {
+        ? localize('Practise trading with {{ctraderBalance}} virtual funds.', {
               ctraderBalance: cTraderAccount.display_balance,
           })
         : localize(

--- a/packages/wallets/src/features/cfd/modals/DxtradeEnterPasswordModal/DxtradeEnterPasswordModal.tsx
+++ b/packages/wallets/src/features/cfd/modals/DxtradeEnterPasswordModal/DxtradeEnterPasswordModal.tsx
@@ -64,7 +64,7 @@ const DxtradeEnterPasswordModal = () => {
 
     const successDescription = useMemo(() => {
         return accountType === 'demo'
-            ? localize("Let's practise trading with {{dxtradeBalance}} virtual funds.", { dxtradeBalance })
+            ? localize('Practise trading with {{dxtradeBalance}} virtual funds.', { dxtradeBalance })
             : localize(
                   'Transfer funds from your {{currency}} Wallet to your {{dxtradeTitle}} account to start trading.',
                   { currency: activeWallet?.currency, dxtradeTitle: PlatformDetails.dxtrade.title }

--- a/packages/wallets/src/features/cfd/modals/MT5AccountAdded/MT5AccountAdded.tsx
+++ b/packages/wallets/src/features/cfd/modals/MT5AccountAdded/MT5AccountAdded.tsx
@@ -101,7 +101,7 @@ const MT5AccountAdded: FC<TProps> = ({ account, marketType, platform, product })
 
     const renderSuccessDescription = useMemo(() => {
         if (isDemo) {
-            return localize("Let's practise trading with {{accountBalance}} virtual funds.", {
+            return localize('Practise trading with {{accountBalance}} virtual funds.', {
                 accountBalance: addedAccount?.display_balance,
             });
         }
@@ -135,7 +135,10 @@ const MT5AccountAdded: FC<TProps> = ({ account, marketType, platform, product })
                         i18n_default_text='Your {{marketTypeTitle}} {{demoTitle}} account is ready'
                         values={{
                             demoTitle: isDemo ? localize('demo') : landingCompanyName,
-                            marketTypeTitle,
+                            marketTypeTitle:
+                                isDemo && platform === CFD_PLATFORMS.MT5
+                                    ? `${CFD_PLATFORMS.MT5.toUpperCase()} ${getMarketTypeDetails(localize, product)[marketType].title}`
+                                    : marketTypeTitle,
                         }}
                     />
                 }

--- a/packages/wallets/src/features/cfd/modals/MT5AccountAdded/__tests__/MT5AccountAdded.spec.tsx
+++ b/packages/wallets/src/features/cfd/modals/MT5AccountAdded/__tests__/MT5AccountAdded.spec.tsx
@@ -74,8 +74,8 @@ describe('MT5AccountAdded', () => {
                 </WalletsAuthProvider>
             </APIProvider>
         );
-        expect(screen.getByText('Your Financial demo account is ready')).toBeInTheDocument();
-        expect(screen.getByText("Let's practise trading with 10,000.00 USD virtual funds.")).toBeInTheDocument();
+        expect(screen.getByText('Your MT5 Financial demo account is ready')).toBeInTheDocument();
+        expect(screen.getByText('Practise trading with 10,000.00 USD virtual funds.')).toBeInTheDocument();
         const okButton = screen.getAllByRole('button', { name: 'OK' })[0];
         expect(okButton).toBeInTheDocument();
         expect(okButton).toBeEnabled();


### PR DESCRIPTION
## Changes:

- [x] Updated content for create MT5 demo account success modal

#### Demo account:
<img width="1728" alt="Bildschirmfoto 2024-11-19 um 10 57 38 AM" src="https://github.com/user-attachments/assets/c0e454e6-349b-4580-9977-683e3f5ab783">

#### Real Account:
<img width="1728" alt="Bildschirmfoto 2024-11-19 um 10 57 20 AM" src="https://github.com/user-attachments/assets/e06ac5d0-4a95-49cb-96d7-040cf5082f60">
