### PR TITLE
chore: trustpilot changes

### DIFF
--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -436,6 +436,7 @@ export default class ClientStore extends BaseStore {
             is_account_to_be_closed_by_residence: computed,
             setClientKYCStatus: action.bound,
             client_kyc_status: observable,
+            should_show_trustpilot_notification: computed,
         });
 
         reaction(
@@ -2949,5 +2950,9 @@ export default class ClientStore extends BaseStore {
 
     setClientKYCStatus(client_kyc_status) {
         this.client_kyc_status = client_kyc_status;
+    }
+
+    get should_show_trustpilot_notification() {
+        return this.account_status?.status?.includes('customer_review_eligible');
     }
 }

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -4,7 +4,6 @@ import { action, computed, makeObservable, observable, reaction } from 'mobx';
 import { StaticUrl } from '@deriv/components';
 import {
     checkServerMaintenance,
-    daysSince,
     extractInfoFromShortcode,
     formatDate,
     formatMoney,
@@ -322,7 +321,6 @@ export default class NotificationStore extends BaseStore {
             account_list,
             account_settings,
             account_status,
-            account_open_date,
             accounts,
             isAccountOfType,
             is_eu,
@@ -353,8 +351,7 @@ export default class NotificationStore extends BaseStore {
         const { current_language, selected_contract_type } = this.root_store.common;
         const malta_account = landing_company_shortcode === 'maltainvest';
         const cr_account = landing_company_shortcode === 'svg';
-        const is_website_up = website_status.site_status === 'up';
-        const has_trustpilot = LocalStore.getObject('notification_messages')[loginid]?.includes(
+        const has_trustpilot = LocalStore.getObject('marked_notifications').includes(
             this.client_notifications.trustpilot?.key
         );
         const is_next_email_attempt_timer_running = shouldShowPhoneVerificationNotification(
@@ -462,6 +459,10 @@ export default class NotificationStore extends BaseStore {
                 this.removeNotificationByKey({
                     key: this.client_notifications.notify_account_is_to_be_closed_by_residence,
                 });
+            }
+
+            if (!has_trustpilot && this.root_store.client.should_show_trustpilot_notification) {
+                this.addNotificationMessage(this.client_notifications.trustpilot);
             }
 
             const client = accounts[loginid];
@@ -629,9 +630,6 @@ export default class NotificationStore extends BaseStore {
                         );
                 } else {
                     this.removeNotificationMessageByKey({ key: this.client_notifications.dp2p?.key });
-                }
-                if (is_website_up && !has_trustpilot && daysSince(account_open_date) > 7) {
-                    this.addNotificationMessage(this.client_notifications.trustpilot);
                 }
                 has_missing_required_field = hasMissingRequiredField(account_settings, client, isAccountOfType);
                 if (has_missing_required_field) {
@@ -845,7 +843,10 @@ export default class NotificationStore extends BaseStore {
                 action: {
                     onClick: () => {
                         window.open('https://www.trustpilot.com/evaluate/deriv.com', '_blank');
-                        this.removeNotificationByKey({ key: this.client_notifications.trustpilot.key });
+                        this.markNotificationMessage({ key: this.client_notifications.trustpilot.key });
+                        this.removeNotificationByKey({
+                            key: this.client_notifications.trustpilot.key,
+                        });
                         this.removeNotificationMessage({
                             key: this.client_notifications.trustpilot.key,
                             should_show_again: false,

--- a/packages/stores/src/mockStore.ts
+++ b/packages/stores/src/mockStore.ts
@@ -320,6 +320,7 @@ const mock = (): TStores & { is_mock: boolean } => {
             account_time_of_closure: undefined,
             is_account_to_be_closed_by_residence: false,
             statement: {},
+            should_show_trustpilot_notification: false,
         },
         common: {
             error: common_store_error,

--- a/packages/stores/types.ts
+++ b/packages/stores/types.ts
@@ -687,6 +687,7 @@ export type TClientStore = {
         poi_status: string;
         valid_tin: 0 | 1;
     };
+    should_show_trustpilot_notification: boolean;
 };
 
 type TCommonStoreError = {


### PR DESCRIPTION
## Changes:

Display Trustpilot Review Notification based on `customer_review_eligible` status received in `get_account_status` API. This PR removes the existing business logic for displaying trustpilot notification.

### Screenshots:

Please provide some screenshots of the change.
