### PR TITLE
[WALL] Lubega / WALL-5148/ Transfer market type API value

### DIFF
--- a/packages/wallets/src/features/cashier/helpers/__tests__/helpers.spec.ts
+++ b/packages/wallets/src/features/cashier/helpers/__tests__/helpers.spec.ts
@@ -1,25 +1,7 @@
 import { LandingCompanyDetails, MT5MarketTypeDetails, PlatformDetails } from '../../constants';
-import { getAccountName, getLandingCompanyNameOfMT5Account, getMarketType } from '../helpers';
+import { getAccountName, getLandingCompanyNameOfMT5Account } from '../helpers';
 
 describe('Cashier Helpers', () => {
-    describe('getMarketType', () => {
-        it('returns correct market type for financial', () => {
-            expect(getMarketType('financial_svg')).toBe(MT5MarketTypeDetails.financial.name);
-        });
-
-        it('returns correct market type for synthetic', () => {
-            expect(getMarketType('synthetic_svg')).toBe(MT5MarketTypeDetails.synthetic.name);
-        });
-
-        it('returns correct market type for all', () => {
-            expect(getMarketType('all_svg')).toBe(MT5MarketTypeDetails.all.name);
-        });
-
-        it('returns undefined for unknown market type', () => {
-            expect(getMarketType('unknown_svg')).toBeUndefined();
-        });
-    });
-
     describe('getLandingCompanyNameOfMT5Account', () => {
         it('returns correct landing company name for BVI', () => {
             expect(getLandingCompanyNameOfMT5Account('financial_bvi')).toBe(LandingCompanyDetails.bvi.name);

--- a/packages/wallets/src/features/cashier/helpers/helpers.ts
+++ b/packages/wallets/src/features/cashier/helpers/helpers.ts
@@ -12,14 +12,6 @@ type TGetAccountNameProps = {
     product?: THooks.AvailableMT5Accounts['product'] | 'stp';
 };
 
-//TODO: remove this function when market_type will be added to transfer_between_accounts response in API
-export const getMarketType = (mt5Group?: string) => {
-    if (mt5Group?.includes(MT5MarketTypeDetails.financial.name)) return MT5MarketTypeDetails.financial.name;
-    if (mt5Group?.includes(MT5MarketTypeDetails.synthetic.name)) return MT5MarketTypeDetails.synthetic.name;
-    if (mt5Group?.includes(MT5MarketTypeDetails.all.name)) return MT5MarketTypeDetails.all.name;
-    return undefined;
-};
-
 //TODO: remove this function when landing_company_name will be added to transfer_between_accounts response in API for mt5 accounts
 export const getLandingCompanyNameOfMT5Account = (mt5Group?: string) => {
     if (mt5Group?.includes(LandingCompanyDetails.bvi.name)) return LandingCompanyDetails.bvi.name;

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowAccountDetails/TransactionsCompletedRowAccountDetails.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowAccountDetails/TransactionsCompletedRowAccountDetails.tsx
@@ -3,8 +3,6 @@ import { Localize } from '@deriv-com/translations';
 import { Text, useDevice } from '@deriv-com/ui';
 import { WalletCurrencyCard, WalletMarketCurrencyIcon } from '../../../../../../../../components';
 import { THooks, TPlatforms } from '../../../../../../../../types';
-import { MARKET_TYPE } from '../../../../../../../cfd/constants';
-import { getMarketType } from '../../../../../../helpers';
 import './TransactionsCompletedRowAccountDetails.scss';
 
 type TProps = {
@@ -15,7 +13,7 @@ type TProps = {
     displayActionType: string;
     isDemo: boolean;
     isInterWallet?: boolean;
-    mt5Group?: string;
+    marketType?: string;
     product?: THooks.AvailableMT5Accounts['product'];
     transactionID?: number;
 };
@@ -28,12 +26,11 @@ const TransactionsCompletedRowAccountDetails: React.FC<TProps> = ({
     displayActionType,
     isDemo,
     isInterWallet = false,
-    mt5Group,
+    marketType,
     product,
     transactionID,
 }) => {
     const { isDesktop } = useDevice();
-    const marketType = getMarketType(mt5Group);
 
     return (
         <div className='wallets-transactions-completed-row-account-details'>
@@ -48,7 +45,7 @@ const TransactionsCompletedRowAccountDetails: React.FC<TProps> = ({
                 <WalletMarketCurrencyIcon
                     currency={currency}
                     isDemo={isDemo}
-                    marketType={marketType ?? MARKET_TYPE.ALL}
+                    marketType={marketType}
                     platform={accountType as TPlatforms.All}
                     product={product}
                 />

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowAccountDetails/__tests__/TransactionsCompletedRowAccountDetails.spec.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowAccountDetails/__tests__/TransactionsCompletedRowAccountDetails.spec.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { getMarketType } from '../../../../../../../helpers';
 import TransactionsCompletedRowAccountDetails from '../TransactionsCompletedRowAccountDetails';
 
 jest.mock('../../../../../../../helpers', () => ({
@@ -46,14 +45,5 @@ describe('TransactionsCompletedRowAccountDetails', () => {
         render(<TransactionsCompletedRowAccountDetails {...defaultProps} isDemo={true} />);
 
         expect(screen.queryByTestId('dt_wallet_list_card_badge')).not.toBeInTheDocument();
-    });
-
-    it('calls getMarketType with correct mt5 group', () => {
-        const mt5Props = {
-            ...defaultProps,
-        };
-        render(<TransactionsCompletedRowAccountDetails {...mt5Props} />);
-
-        expect(getMarketType).toHaveBeenCalledWith('mocked mt5 group');
     });
 });

--- a/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowTransferAccountDetails/TransactionsCompletedRowTransferAccountDetails.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transactions/components/TransactionsCompletedRow/components/TransactionsCompletedRowTransferAccountDetails/TransactionsCompletedRowTransferAccountDetails.tsx
@@ -49,7 +49,7 @@ const TransactionsCompletedRowTransferAccountDetails: React.FC<TProps> = ({
                 displayActionType={displayActionType}
                 isDemo={Boolean(transferAccount.is_virtual)}
                 isInterWallet={transferAccount === wallet}
-                mt5Group={transferAccount === mt5Account ? mt5Account.group : undefined}
+                marketType={transferAccount === mt5Account ? mt5Account.market_type : undefined}
                 product={mt5Account?.product}
                 transactionID={transactionID}
             />

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useExtendedTransferAccountProperties.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useExtendedTransferAccountProperties.ts
@@ -3,7 +3,7 @@ import { useActiveWalletAccount, useCurrencyConfig } from '@deriv/api-v2';
 import { displayMoney } from '@deriv/api-v2/src/utils';
 import { THooks, TWalletLandingCompanyName } from '../../../../../types';
 import { PlatformDetails } from '../../../constants';
-import { getAccountName, getLandingCompanyNameOfMT5Account, getMarketType } from '../../../helpers';
+import { getAccountName, getLandingCompanyNameOfMT5Account } from '../../../helpers';
 
 /** A custom hook that enhances the transfer accounts response by adding additional properties for convenient UI rendering. */
 const useExtendedTransferAccountProperties = (accounts?: THooks.TransferAccount[]) => {
@@ -21,7 +21,7 @@ const useExtendedTransferAccountProperties = (accounts?: THooks.TransferAccount[
                 accountType: account.account_type,
                 displayCurrencyCode: currencyConfig?.display_code,
                 landingCompanyName: activeWallet?.landing_company_name as TWalletLandingCompanyName,
-                mt5MarketType: getMarketType(account.mt5_group),
+                mt5MarketType: account.market_type,
                 product: account.product,
             });
             const displayBalance = displayMoney(Number(account.balance), currencyConfig?.display_code, {

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useSortedTransferAccounts.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useSortedTransferAccounts.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import { MT5MarketTypeDetails, PlatformDetails } from '../../../constants';
-import { getMarketType } from '../../../helpers';
 import { TAccount, TAccountsList } from '../types';
 
 const useSortedTransferAccounts = (accounts: TAccountsList) => {
@@ -69,8 +68,8 @@ const sortTradingAccounts = (a: TAccount, b: TAccount) => {
 
     // For mt5 accounts, compare market types
     if (typeA === PlatformDetails.mt5.name) {
-        const marketTypeA = getMarketType(a.mt5_group);
-        const marketTypeB = getMarketType(b.mt5_group);
+        const marketTypeA = a.market_type;
+        const marketTypeB = b.market_type;
 
         if (
             marketTypeOrder[marketTypeA ?? MT5MarketTypeDetails.all.name] !==


### PR DESCRIPTION
## Changes:

- [x] Change market_type to fetch directly from newly-added API value instead of mapping it based on the updated mt5_group value
- [x] Remove getMarketType function 

### Bug:

![image](https://github.com/user-attachments/assets/67a566f7-0156-40fa-b685-737f6a64acd1)

### Fix:
<img width="1379" alt="Bildschirmfoto 2024-11-20 um 10 49 37 AM" src="https://github.com/user-attachments/assets/4e8b9a17-4cd4-4d1c-843f-80e2879f8466">
<img width="1379" alt="Bildschirmfoto 2024-11-20 um 10 47 51 AM" src="https://github.com/user-attachments/assets/4ccc4ab5-ab7c-4fe4-a30b-e9f5a692630c">
