### PR TITLE
[WALL] Lubega / WALL-5053 / Change password success modal content update

### DIFF
--- a/packages/wallets/src/components/WalletsResetMT5Password/WalletSuccessResetMT5Password.tsx
+++ b/packages/wallets/src/components/WalletsResetMT5Password/WalletSuccessResetMT5Password.tsx
@@ -20,7 +20,7 @@ const WalletSuccessResetMT5Password: FC<WalletSuccessResetMT5PasswordProps> = ({
 
     const renderButtons = (
         <Button isFullWidth={!isDesktop} onClick={onClick} size='lg' textSize='sm'>
-            {isInvestorPassword ? localize('Ok') : localize('Done')}
+            {localize('OK')}
         </Button>
     );
 
@@ -28,11 +28,7 @@ const WalletSuccessResetMT5Password: FC<WalletSuccessResetMT5PasswordProps> = ({
         <ModalStepWrapper
             renderFooter={isDesktop ? undefined : () => renderButtons}
             shouldHideFooter={isDesktop}
-            title={
-                isInvestorPassword
-                    ? localize('Reset {{title}} password', { title })
-                    : localize('Manage {{title}} password', { title })
-            }
+            title={isInvestorPassword ? localize('Reset {{title}} password', { title }) : localize('Success')}
         >
             <div className='wallets-reset-mt5-password'>
                 <ActionScreen
@@ -40,10 +36,9 @@ const WalletSuccessResetMT5Password: FC<WalletSuccessResetMT5PasswordProps> = ({
                     description={
                         isInvestorPassword
                             ? localize('Your investor password has been changed.')
-                            : localize(
-                                  'You have a new {{title}} password to log in to your {{title}} accounts on the web and mobile apps.',
-                                  { title }
-                              )
+                            : localize('You can log in to all your {{title}} accounts with your new password.', {
+                                  title,
+                              })
                     }
                     descriptionSize='sm'
                     icon={
@@ -53,7 +48,7 @@ const WalletSuccessResetMT5Password: FC<WalletSuccessResetMT5PasswordProps> = ({
                             <DerivLightMt5SuccessPasswordResetIcon height={100} width={100} />
                         )
                     }
-                    title={isInvestorPassword ? localize('Password saved') : localize('Success')}
+                    title={isInvestorPassword ? localize('Password saved') : undefined}
                 />
             </div>
         </ModalStepWrapper>

--- a/packages/wallets/src/components/WalletsResetMT5Password/__test__/WalletSuccessResetMT5Password.spec.tsx
+++ b/packages/wallets/src/components/WalletsResetMT5Password/__test__/WalletSuccessResetMT5Password.spec.tsx
@@ -45,25 +45,20 @@ describe('<WalletsErrorMT5InvestorPassword />', () => {
         expect(screen.getByText('Reset mocked password'));
         expect(screen.getByText('Password saved'));
         expect(screen.getByText('Your investor password has been changed.'));
-        expect(screen.getByRole('button', { name: 'Ok' }));
+        expect(screen.getByRole('button', { name: 'OK' }));
     });
 
     it('should render content if isInvestorPassword is false', () => {
         render(<WalletSuccessResetMT5Password {...props} />, { wrapper });
-        expect(screen.getByText('Manage mocked password'));
         expect(screen.getByText('Success'));
-        expect(
-            screen.getByText(
-                'You have a new mocked password to log in to your mocked accounts on the web and mobile apps.'
-            )
-        );
-        expect(screen.getByRole('button', { name: 'Done' }));
+        expect(screen.getByText('You can log in to all your mocked accounts with your new password.'));
+        expect(screen.getByRole('button', { name: 'OK' }));
     });
 
     it('should execute function onClick when button is clicked', async () => {
         render(<WalletSuccessResetMT5Password {...props} />, { wrapper });
-        expect(screen.getByRole('button', { name: 'Done' }));
-        await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+        expect(screen.getByRole('button', { name: 'OK' }));
+        await userEvent.click(screen.getByRole('button', { name: 'OK' }));
         expect(props.onClick).toBeCalled();
     });
 


### PR DESCRIPTION
## Changes:

- [x] Update content of change password success modal

### Screenshots:

<img width="1289" alt="Bildschirmfoto 2024-11-21 um 10 38 51 AM" src="https://github.com/user-attachments/assets/e1d1f484-04ac-46c4-b075-c989e5074f59">
<img width="375" alt="Bildschirmfoto 2024-11-21 um 10 40 02 AM" src="https://github.com/user-attachments/assets/19087454-381d-4f86-9519-4ead9ef0dc46">
