### PR TITLE
[WALL] Jim/WALL-5145/iframe is not loading for XRP

### DIFF
--- a/packages/cashier/src/stores/general-store.ts
+++ b/packages/cashier/src/stores/general-store.ts
@@ -19,6 +19,7 @@ export default class GeneralStore extends BaseStore {
             init: action.bound,
             is_cashier_onboarding: observable,
             is_crypto: computed,
+            is_crypto_provider: computed,
             is_deposit: observable,
             is_loading: observable,
             onMountCommon: action.bound,
@@ -73,10 +74,18 @@ export default class GeneralStore extends BaseStore {
     setOnRemount(func: VoidFunction): void {
         this.onRemount = func;
     }
-
+    /**
+     * @deprecated This is a legacy method and should not be used. Please use `is_crypto_provider` instead.
+     */
     get is_crypto(): boolean {
         const { currency } = this.root_store.client;
         return !!currency && isCryptocurrency(currency);
+    }
+
+    get is_crypto_provider(): boolean {
+        const { currency, website_status } = this.root_store.client;
+        //@ts-expect-error we need to update the api-types version
+        return !!website_status?.currencies_config[currency].platform.cashier.includes('crypto');
     }
 
     calculatePercentage(amount = this.root_store.modules.cashier.crypto_fiat_converter.converter_from_amount): void {

--- a/packages/cashier/src/stores/general-store.ts
+++ b/packages/cashier/src/stores/general-store.ts
@@ -85,7 +85,7 @@ export default class GeneralStore extends BaseStore {
     get is_crypto_provider(): boolean {
         const { currency, website_status } = this.root_store.client;
         //@ts-expect-error we need to update the api-types version
-        return !!website_status?.currencies_config[currency].platform.cashier.includes('crypto');
+        return website_status?.currencies_config[currency].platform.cashier.includes('crypto');
     }
 
     calculatePercentage(amount = this.root_store.modules.cashier.crypto_fiat_converter.converter_from_amount): void {

--- a/packages/cashier/src/stores/withdraw-store.ts
+++ b/packages/cashier/src/stores/withdraw-store.ts
@@ -174,7 +174,7 @@ export default class WithdrawStore {
     async onMountWithdraw(verification_code?: string) {
         const { client, modules } = this.root_store;
         const active_container = modules.cashier?.general_store.active_container;
-        const is_crypto = modules.cashier?.general_store.is_crypto;
+        const is_crypto_provider = modules.cashier?.general_store.is_crypto_provider;
         const onMountCommon = modules.cashier?.general_store.onMountCommon;
         const setLoading = modules.cashier?.general_store.setLoading;
         const setOnRemount = modules.cashier?.general_store.setOnRemount;
@@ -231,7 +231,7 @@ export default class WithdrawStore {
 
                 client.setVerificationCode('', container);
             }
-        } else if (is_crypto && client.currency !== 'XRP') {
+        } else if (is_crypto_provider) {
             setLoading(false);
         } else {
             await checkIframeLoaded();
@@ -306,7 +306,7 @@ export default class WithdrawStore {
         const remainder = client.account_limits?.remainder;
         this.setMaxWithdrawAmount(Number(remainder));
 
-        const fractional_digit = Math.pow(10, -getDecimalPlaces(client.currency));
+        const fractional_digit = 10 ** -getDecimalPlaces(client.currency);
         const min_withdrawal = getMinWithdrawal(client.currency);
         const is_limit_reached = !!(
             typeof remainder !== 'undefined' &&
@@ -350,7 +350,7 @@ export default class WithdrawStore {
 
         const min_withdraw_amount =
             currency === 'XRP'
-                ? Math.pow(10, -getDecimalPlaces(client.currency))
+                ? 10 ** -getDecimalPlaces(client.currency)
                 : Number(this.crypto_config?.currencies_config?.[currency]?.minimum_withdrawal);
         const max_withdraw_amount =
             Number(this.max_withdraw_amount) > Number(balance) ? Number(balance) : Number(this.max_withdraw_amount);

--- a/packages/cashier/src/stores/withdraw-store.ts
+++ b/packages/cashier/src/stores/withdraw-store.ts
@@ -231,7 +231,7 @@ export default class WithdrawStore {
 
                 client.setVerificationCode('', container);
             }
-        } else if (is_crypto) {
+        } else if (is_crypto && client.currency !== 'XRP') {
             setLoading(false);
         } else {
             await checkIframeLoaded();
@@ -306,7 +306,7 @@ export default class WithdrawStore {
         const remainder = client.account_limits?.remainder;
         this.setMaxWithdrawAmount(Number(remainder));
 
-        const fractional_digit = Math.pow(10, -getDecimalPlaces(client.currency));
+        const fractional_digit = 10 ** -getDecimalPlaces(client.currency);
         const min_withdrawal = getMinWithdrawal(client.currency);
         const is_limit_reached = !!(
             typeof remainder !== 'undefined' &&
@@ -350,7 +350,7 @@ export default class WithdrawStore {
 
         const min_withdraw_amount =
             currency === 'XRP'
-                ? Math.pow(10, -getDecimalPlaces(client.currency))
+                ? 10 ** -getDecimalPlaces(client.currency)
                 : Number(this.crypto_config?.currencies_config?.[currency]?.minimum_withdrawal);
         const max_withdraw_amount =
             Number(this.max_withdraw_amount) > Number(balance) ? Number(balance) : Number(this.max_withdraw_amount);

--- a/packages/cashier/src/stores/withdraw-store.ts
+++ b/packages/cashier/src/stores/withdraw-store.ts
@@ -306,7 +306,7 @@ export default class WithdrawStore {
         const remainder = client.account_limits?.remainder;
         this.setMaxWithdrawAmount(Number(remainder));
 
-        const fractional_digit = 10 ** -getDecimalPlaces(client.currency);
+        const fractional_digit = Math.pow(10, -getDecimalPlaces(client.currency));
         const min_withdrawal = getMinWithdrawal(client.currency);
         const is_limit_reached = !!(
             typeof remainder !== 'undefined' &&
@@ -350,7 +350,7 @@ export default class WithdrawStore {
 
         const min_withdraw_amount =
             currency === 'XRP'
-                ? 10 ** -getDecimalPlaces(client.currency)
+                ? Math.pow(10, -getDecimalPlaces(client.currency))
                 : Number(this.crypto_config?.currencies_config?.[currency]?.minimum_withdrawal);
         const max_withdraw_amount =
             Number(this.max_withdraw_amount) > Number(balance) ? Number(balance) : Number(this.max_withdraw_amount);


### PR DESCRIPTION
## Changes:
Added conditional to check if `client.currency !== 'XRP'`, so that `XRP` is redirected to the `else` branch where the `iframe url` will be set and the `withdrawal page` will therefore be displayed.

### Screenshots:

<img width="1452" alt="image" src="https://github.com/user-attachments/assets/cb94599b-1858-4c74-b8a3-0fd72f5a4386">

<img width="1453" alt="image" src="https://github.com/user-attachments/assets/1b5fc386-cb0a-414b-b22a-5c6326b961a5">


https://github.com/user-attachments/assets/7800e91e-af7a-4f0c-9ec3-a0e12adfec75

https://github.com/user-attachments/assets/dffc0fd0-6b2a-4b4f-ae25-2712217bbcd2


