### PR TITLE
Akmal / fix: show max payout details at all times

### DIFF
--- a/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
@@ -98,7 +98,7 @@ const Stake = observer(({ is_minimized }: TTradeParametersProps) => {
         is_max_payout_exceeded && proposal_error_message
             ? Number(proposal_error_message.match(float_number_search_regex)?.[1])
             : 0;
-    const { payout, stake } = validation_params[contract_types[0]] ?? {};
+    const { payout, stake } = validation_params[contract_types[0]] ?? validation_params[contract_types[1]] ?? {};
     const { max: max_payout = error_max_payout } = payout ?? {};
     const { max: max_stake = 0, min: min_stake = 0 } = stake ?? {};
     const error_payout_1 = proposal_error_message_1


### PR DESCRIPTION
## Changes:

This fix ensures that maximum payout details are always visible, providing users with consistent access to critical information.

1. Persistent Display: Keep maximum payout details visible at all times, regardless of user actions or settings changes.
2. Enhanced Clarity: Ensure users have continuous access to payout information, improving decision-making during trade configuration.
3. Improved User Experience: Prevent confusion by making important payout details consistently available.

This fix enhances usability and transparency by ensuring maximum payout details remain visible throughout the trading process.

