### PR TITLE
[BOT]maryia/GRWT-2382/fix: Run panel animation result does not match contact result on win/loss

### DIFF
--- a/packages/bot-web-ui/src/stores/summary-card-store.ts
+++ b/packages/bot-web-ui/src/stores/summary-card-store.ts
@@ -156,11 +156,11 @@ export default class SummaryCardStore {
     onBotContractEvent(contract: TContractInfo) {
         const { profit } = contract;
         const indicative = getIndicativePrice(contract as ProposalOpenContract);
+        this.profit = profit;
 
         if (this.contract_id !== contract.id) {
             this.clear(false);
             this.contract_id = contract.id;
-            this.profit = profit;
             this.indicative = indicative;
         }
 


### PR DESCRIPTION


## Changes:

fix: Run panel animation result does not match contact result on win/loss

!we need the value of each transaction of the profit field relative to one contract, not just the first one

### Screenshots:

Please provide some screenshots of the change.
