### PR TITLE
[WALL] Lubega / WALL-5155 / MT5ResetPaswordModal unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the various platforms of the Deriv application.
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org/)
 ![Sonar Tech Debt](https://img.shields.io/sonar/tech_debt/binary-com_deriv-app?server=https%3A%2F%2Fsonarcloud.io)
 ![Sonar Violations (short format)](https://img.shields.io/sonar/violations/binary-com_deriv-app?server=https%3A%2F%2Fsonarcloud.io)
-[![Coverage Status](https://coveralls.io/repos/github/binary-com/deriv-app/badge.svg?branch=master)](https://coveralls.io/github/binary-com/deriv-app?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/deriv-com/deriv-app/badge.svg?branch=master)](https://coveralls.io/github/deriv-com/deriv-app?branch=master)
 
 **In this document**:
 

--- a/packages/wallets/src/features/cfd/screens/MT5ResetPasswordModal/__tests__/MT5ResetPasswordModal.spec.tsx
+++ b/packages/wallets/src/features/cfd/screens/MT5ResetPasswordModal/__tests__/MT5ResetPasswordModal.spec.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { useDevice } from '@deriv-com/ui';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MT5ResetPasswordModal from '../MT5ResetPasswordModal';
+
+jest.mock('@deriv-com/ui', () => ({
+    ...jest.requireActual('@deriv-com/ui'),
+    useDevice: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../../components', () => ({
+    ...jest.requireActual('../../../../../components'),
+    WalletPasswordFieldLazy: ({
+        label,
+        onChange,
+        password,
+        serverErrorMessage,
+    }: {
+        label: string;
+        onChange: () => void;
+        password: string;
+        serverErrorMessage?: string;
+    }) => (
+        <>
+            <input
+                data-testid='dt_password_field'
+                onChange={onChange}
+                placeholder={label}
+                type='password'
+                value={password}
+            />
+            {serverErrorMessage && <div>{serverErrorMessage}</div>}
+        </>
+    ),
+}));
+
+jest.mock('../../../../../utils/password-validation', () => ({
+    validPasswordMT5: jest.fn(() => ({})),
+}));
+
+describe('MT5ResetPasswordModal', () => {
+    const mockOnSubmit = jest.fn();
+    const mockSendEmailVerification = jest.fn();
+
+    beforeEach(() => {
+        (useDevice as jest.Mock).mockReturnValue({ isDesktop: true });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders without crashing', () => {
+        render(
+            <MT5ResetPasswordModal
+                formError={null}
+                isLoading={false}
+                onClickSubmitPasswordChange={mockOnSubmit}
+                sendEmailVerification={mockSendEmailVerification}
+            />
+        );
+
+        expect(screen.getByText('Deriv MT5 latest password requirements')).toBeInTheDocument();
+        expect(screen.getByText('Change my password')).toBeInTheDocument();
+        expect(screen.getByPlaceholderText('Current password')).toBeInTheDocument();
+        expect(screen.getByPlaceholderText('New Password')).toBeInTheDocument();
+    });
+
+    it('displays the correct error message for invalid current password', async () => {
+        const formError = { error: { code: 'PasswordError', message: 'Invalid password' } };
+
+        render(
+            <MT5ResetPasswordModal
+                // @ts-expect-error Partial error mock
+                formError={formError}
+                isLoading={false}
+                onClickSubmitPasswordChange={mockOnSubmit}
+                sendEmailVerification={mockSendEmailVerification}
+            />
+        );
+
+        expect(screen.getByText('Invalid password')).toBeInTheDocument();
+    });
+
+    it('displays the correct error message for other error messages', async () => {
+        const formError = { error: { code: 'Error', message: 'Error message' } };
+
+        render(
+            <MT5ResetPasswordModal
+                // @ts-expect-error Partial error mock
+                formError={formError}
+                isLoading={false}
+                onClickSubmitPasswordChange={mockOnSubmit}
+                sendEmailVerification={mockSendEmailVerification}
+            />
+        );
+
+        expect(screen.getByText('Error message')).toBeInTheDocument();
+    });
+
+    it('calls sendEmailVerification when forgot password button is clicked', async () => {
+        render(
+            <MT5ResetPasswordModal
+                formError={null}
+                isLoading={false}
+                onClickSubmitPasswordChange={mockOnSubmit}
+                sendEmailVerification={mockSendEmailVerification}
+            />
+        );
+
+        await userEvent.click(screen.getByText('Forgot password?'));
+        expect(mockSendEmailVerification).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClickSubmitPasswordChange on form submission', async () => {
+        render(
+            <MT5ResetPasswordModal
+                formError={null}
+                isLoading={false}
+                onClickSubmitPasswordChange={mockOnSubmit}
+                sendEmailVerification={mockSendEmailVerification}
+            />
+        );
+
+        const currentPasswordInput = screen.getByPlaceholderText('Current password');
+        const newPasswordInput = screen.getByPlaceholderText('New Password');
+
+        await userEvent.type(currentPasswordInput, 'Abcd1234!');
+        await userEvent.type(newPasswordInput, 'Password123!');
+        await userEvent.click(screen.getByText('Change my password'));
+        await waitFor(() => {
+            expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it('does not render the header on mobile', () => {
+        (useDevice as jest.Mock).mockReturnValue({ isDesktop: false });
+        render(
+            <MT5ResetPasswordModal
+                formError={null}
+                isLoading={false}
+                onClickSubmitPasswordChange={mockOnSubmit}
+                sendEmailVerification={mockSendEmailVerification}
+            />
+        );
+
+        expect(screen.queryByText(/latest password requirements/)).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Changes:

- [x] Added unit test for MT5ResetPaswordModal
- [x] Updated coveralls link in readme fiel to deriv-com/deriv-app instead of binary-com/deriv-app

### Screenshots:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/2eedd299-5ed0-4217-8682-97f149ddc196">