### PR TITLE
Akmal / chore: update quill-ui version to 1.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
             "dependencies": {
                 "@babel/preset-typescript": "^7.24.7",
                 "@deriv-com/analytics": "1.26.2",
-                "@deriv/deriv-charts": "^2.7.1",
                 "@sendbird/chat": "^4.9.7",
                 "@types/react-transition-group": "^4.4.4",
                 "babel-jest": "^29.7.0",
@@ -2733,188 +2732,6 @@
                 "@types/lodash": "^4.14.197",
                 "lodash": "^4.17.21",
                 "remove": "^0.1.5"
-            }
-        },
-        "node_modules/@deriv-com/quill-ui": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/@deriv-com/quill-ui/-/quill-ui-1.21.0.tgz",
-            "integrity": "sha512-oGj77KxudGth/ZVJN599HKYpDqu213dGlFN69/WltGC61jZfk0gOVhudWacLe2v7i0lb50RKfbCIh3L3ldtZTw==",
-            "dependencies": {
-                "@deriv-com/quill-tokens": "^2.0.13",
-                "@deriv/quill-icons": "^1.22.10",
-                "@headlessui/react": "1.7.18",
-                "dayjs": "^1.11.11",
-                "react-calendar": "^5.0.0",
-                "react-number-format": "^5.4.0",
-                "react-swipeable": "^6.2.1",
-                "react-tiny-popover": "^8.0.4",
-                "react-transition-group": "4.4.2",
-                "usehooks-ts": "^3.0.2",
-                "uuid": "^9.0.1"
-            },
-            "optionalDependencies": {
-                "@rollup/rollup-linux-x64-gnu": "^4.22.4"
-            }
-        },
-        "node_modules/@deriv-com/quill-ui/node_modules/@deriv-com/quill-tokens": {
-            "version": "2.0.13",
-            "resolved": "https://registry.npmjs.org/@deriv-com/quill-tokens/-/quill-tokens-2.0.13.tgz",
-            "integrity": "sha512-TMzgQkwCcg/wuiXMYfWoI9RxQsmDJIljdYxmvePvLsMOl43eyIo3PVGy0sTMsjlZJUzh8G0UzyF1tLBdpy3URA==",
-            "dependencies": {
-                "@semantic-release/changelog": "^6.0.3",
-                "@semantic-release/github": "^10.0.4",
-                "@semantic-release/npm": "^12.0.1",
-                "@semantic-release/release-notes-generator": "^14.0.1",
-                "@types/lodash": "^4.14.197",
-                "lodash": "^4.17.21",
-                "remove": "^0.1.5"
-            }
-        },
-        "node_modules/@deriv-com/quill-ui/node_modules/@headlessui/react": {
-            "version": "1.7.18",
-            "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.18.tgz",
-            "integrity": "sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==",
-            "dependencies": {
-                "@tanstack/react-virtual": "^3.0.0-beta.60",
-                "client-only": "^0.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "react": "^16 || ^17 || ^18",
-                "react-dom": "^16 || ^17 || ^18"
-            }
-        },
-        "node_modules/@deriv-com/quill-ui/node_modules/@semantic-release/release-notes-generator": {
-            "version": "14.0.1",
-            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.0.1.tgz",
-            "integrity": "sha512-K0w+5220TM4HZTthE5dDpIuFrnkN1NfTGPidJFm04ULT1DEZ9WG89VNXN7F0c+6nMEpWgqmPvb7vY7JkB2jyyA==",
-            "dependencies": {
-                "conventional-changelog-angular": "^8.0.0",
-                "conventional-changelog-writer": "^8.0.0",
-                "conventional-commits-filter": "^5.0.0",
-                "conventional-commits-parser": "^6.0.0",
-                "debug": "^4.0.0",
-                "get-stream": "^7.0.0",
-                "import-from-esm": "^1.0.3",
-                "into-stream": "^7.0.0",
-                "lodash-es": "^4.17.21",
-                "read-package-up": "^11.0.0"
-            },
-            "engines": {
-                "node": ">=20.8.1"
-            },
-            "peerDependencies": {
-                "semantic-release": ">=20.1.0"
-            }
-        },
-        "node_modules/@deriv-com/quill-ui/node_modules/conventional-changelog-angular": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
-            "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
-            "dependencies": {
-                "compare-func": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@deriv-com/quill-ui/node_modules/conventional-changelog-writer": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.0.0.tgz",
-            "integrity": "sha512-TQcoYGRatlAnT2qEWDON/XSfnVG38JzA7E0wcGScu7RElQBkg9WWgZd1peCWFcWDh1xfb2CfsrcvOn1bbSzztA==",
-            "dependencies": {
-                "@types/semver": "^7.5.5",
-                "conventional-commits-filter": "^5.0.0",
-                "handlebars": "^4.7.7",
-                "meow": "^13.0.0",
-                "semver": "^7.5.2"
-            },
-            "bin": {
-                "conventional-changelog-writer": "dist/cli/index.js"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@deriv-com/quill-ui/node_modules/conventional-commits-filter": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-            "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@deriv-com/quill-ui/node_modules/conventional-commits-parser": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.0.0.tgz",
-            "integrity": "sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==",
-            "dependencies": {
-                "meow": "^13.0.0"
-            },
-            "bin": {
-                "conventional-commits-parser": "dist/cli/index.js"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@deriv-com/quill-ui/node_modules/meow": {
-            "version": "13.2.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-            "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@deriv-com/quill-ui/node_modules/react-tiny-popover": {
-            "version": "8.1.2",
-            "resolved": "https://registry.npmjs.org/react-tiny-popover/-/react-tiny-popover-8.1.2.tgz",
-            "integrity": "sha512-zzG9hGBCNeSesZLLItNOiQvIU+/tLdLQ9y8cfSAtLQnOH7eoKVJflQzEng8w7rTblE+cV0/R6dFjjiZS1A4qTA==",
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-            }
-        },
-        "node_modules/@deriv-com/quill-ui/node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@deriv-com/quill-ui/node_modules/usehooks-ts": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.0.tgz",
-            "integrity": "sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==",
-            "dependencies": {
-                "lodash.debounce": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=16.15.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0  || ^17 || ^18"
-            }
-        },
-        "node_modules/@deriv-com/quill-ui/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@deriv-com/translations": {
@@ -50501,7 +50318,7 @@
             "dependencies": {
                 "@binary-com/binary-document-uploader": "^2.4.8",
                 "@deriv-com/analytics": "1.26.2",
-                "@deriv-com/quill-ui": "1.21.0",
+                "@deriv-com/quill-ui": "1.24.0",
                 "@deriv-com/translations": "1.3.9",
                 "@deriv-com/ui": "1.36.4",
                 "@deriv-com/utils": "^0.0.36",
@@ -50566,6 +50383,210 @@
             },
             "engines": {
                 "node": "18.x"
+            }
+        },
+        "packages/account/node_modules/@deriv-com/quill-tokens": {
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/@deriv-com/quill-tokens/-/quill-tokens-2.0.13.tgz",
+            "integrity": "sha512-TMzgQkwCcg/wuiXMYfWoI9RxQsmDJIljdYxmvePvLsMOl43eyIo3PVGy0sTMsjlZJUzh8G0UzyF1tLBdpy3URA==",
+            "license": "ISC",
+            "dependencies": {
+                "@semantic-release/changelog": "^6.0.3",
+                "@semantic-release/github": "^10.0.4",
+                "@semantic-release/npm": "^12.0.1",
+                "@semantic-release/release-notes-generator": "^14.0.1",
+                "@types/lodash": "^4.14.197",
+                "lodash": "^4.17.21",
+                "remove": "^0.1.5"
+            }
+        },
+        "packages/account/node_modules/@deriv-com/quill-ui": {
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@deriv-com/quill-ui/-/quill-ui-1.24.0.tgz",
+            "integrity": "sha512-xzsnaX06RcqNV27kpvvSJOq93Nbho/W+Ms3DkyLNpctJK8dz+RCm+1rGCFwpxaQkeXCtRIMtTIR+k2lYzaHpVw==",
+            "dependencies": {
+                "@deriv-com/quill-tokens": "^2.0.13",
+                "@deriv/quill-icons": "^2.2.0",
+                "@headlessui/react": "1.7.18",
+                "dayjs": "^1.11.11",
+                "react-calendar": "^5.0.0",
+                "react-number-format": "^5.4.0",
+                "react-swipeable": "^6.2.1",
+                "react-tiny-popover": "^8.0.4",
+                "react-transition-group": "4.4.2",
+                "usehooks-ts": "^3.0.2",
+                "uuid": "^9.0.1"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-linux-x64-gnu": "^4.22.4"
+            }
+        },
+        "packages/account/node_modules/@deriv-com/quill-ui/node_modules/@deriv/quill-icons": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-2.2.0.tgz",
+            "integrity": "sha512-mR9PRYdO9L0usFtGcbFih7hqgi9Ky3y95QM22VEzjrX+Tktf0L0gkJP3XYwxMQRTxc6x4FBJzYw2UY+dGn4RrQ==",
+            "license": "ISC",
+            "peerDependencies": {
+                "react": ">= 16",
+                "react-dom": ">= 16"
+            }
+        },
+        "packages/account/node_modules/@deriv-com/quill-ui/node_modules/@headlessui/react": {
+            "version": "1.7.18",
+            "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.18.tgz",
+            "integrity": "sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/react-virtual": "^3.0.0-beta.60",
+                "client-only": "^0.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "react": "^16 || ^17 || ^18",
+                "react-dom": "^16 || ^17 || ^18"
+            }
+        },
+        "packages/account/node_modules/@deriv-com/quill-ui/node_modules/react-tiny-popover": {
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/react-tiny-popover/-/react-tiny-popover-8.1.4.tgz",
+            "integrity": "sha512-rHNAosGfUwlkOQeTJ+fCX/lHUOuMmgQZVhtRBnU9DqAONgltSv1QIZHeG1FGvZIGg7y7wbV4H6wriDuiSssIfQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "packages/account/node_modules/@deriv-com/quill-ui/node_modules/usehooks-ts": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.0.tgz",
+            "integrity": "sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==",
+            "license": "MIT",
+            "dependencies": {
+                "lodash.debounce": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=16.15.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0  || ^17 || ^18"
+            }
+        },
+        "packages/account/node_modules/@semantic-release/release-notes-generator": {
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.0.1.tgz",
+            "integrity": "sha512-K0w+5220TM4HZTthE5dDpIuFrnkN1NfTGPidJFm04ULT1DEZ9WG89VNXN7F0c+6nMEpWgqmPvb7vY7JkB2jyyA==",
+            "license": "MIT",
+            "dependencies": {
+                "conventional-changelog-angular": "^8.0.0",
+                "conventional-changelog-writer": "^8.0.0",
+                "conventional-commits-filter": "^5.0.0",
+                "conventional-commits-parser": "^6.0.0",
+                "debug": "^4.0.0",
+                "get-stream": "^7.0.0",
+                "import-from-esm": "^1.0.3",
+                "into-stream": "^7.0.0",
+                "lodash-es": "^4.17.21",
+                "read-package-up": "^11.0.0"
+            },
+            "engines": {
+                "node": ">=20.8.1"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=20.1.0"
+            }
+        },
+        "packages/account/node_modules/conventional-changelog-angular": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
+            "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
+            "license": "ISC",
+            "dependencies": {
+                "compare-func": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/account/node_modules/conventional-changelog-writer": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.0.0.tgz",
+            "integrity": "sha512-TQcoYGRatlAnT2qEWDON/XSfnVG38JzA7E0wcGScu7RElQBkg9WWgZd1peCWFcWDh1xfb2CfsrcvOn1bbSzztA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/semver": "^7.5.5",
+                "conventional-commits-filter": "^5.0.0",
+                "handlebars": "^4.7.7",
+                "meow": "^13.0.0",
+                "semver": "^7.5.2"
+            },
+            "bin": {
+                "conventional-changelog-writer": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/account/node_modules/conventional-commits-filter": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+            "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/account/node_modules/conventional-commits-parser": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.0.0.tgz",
+            "integrity": "sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==",
+            "license": "MIT",
+            "dependencies": {
+                "meow": "^13.0.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/account/node_modules/meow": {
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+            "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/account/node_modules/semver": {
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/account/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "packages/api": {
@@ -50757,7 +50778,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@deriv-com/quill-ui": "1.21.0",
+                "@deriv-com/quill-ui": "1.24.0",
                 "@deriv-com/ui": "1.36.4",
                 "@deriv/api": "^1.0.0",
                 "@deriv/api-types": "1.0.172",
@@ -50833,6 +50854,173 @@
                 "node": "18.x"
             }
         },
+        "packages/bot-web-ui/node_modules/@deriv-com/quill-tokens": {
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/@deriv-com/quill-tokens/-/quill-tokens-2.0.13.tgz",
+            "integrity": "sha512-TMzgQkwCcg/wuiXMYfWoI9RxQsmDJIljdYxmvePvLsMOl43eyIo3PVGy0sTMsjlZJUzh8G0UzyF1tLBdpy3URA==",
+            "license": "ISC",
+            "dependencies": {
+                "@semantic-release/changelog": "^6.0.3",
+                "@semantic-release/github": "^10.0.4",
+                "@semantic-release/npm": "^12.0.1",
+                "@semantic-release/release-notes-generator": "^14.0.1",
+                "@types/lodash": "^4.14.197",
+                "lodash": "^4.17.21",
+                "remove": "^0.1.5"
+            }
+        },
+        "packages/bot-web-ui/node_modules/@deriv-com/quill-ui": {
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@deriv-com/quill-ui/-/quill-ui-1.24.0.tgz",
+            "integrity": "sha512-xzsnaX06RcqNV27kpvvSJOq93Nbho/W+Ms3DkyLNpctJK8dz+RCm+1rGCFwpxaQkeXCtRIMtTIR+k2lYzaHpVw==",
+            "dependencies": {
+                "@deriv-com/quill-tokens": "^2.0.13",
+                "@deriv/quill-icons": "^2.2.0",
+                "@headlessui/react": "1.7.18",
+                "dayjs": "^1.11.11",
+                "react-calendar": "^5.0.0",
+                "react-number-format": "^5.4.0",
+                "react-swipeable": "^6.2.1",
+                "react-tiny-popover": "^8.0.4",
+                "react-transition-group": "4.4.2",
+                "usehooks-ts": "^3.0.2",
+                "uuid": "^9.0.1"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-linux-x64-gnu": "^4.22.4"
+            }
+        },
+        "packages/bot-web-ui/node_modules/@deriv-com/quill-ui/node_modules/@deriv/quill-icons": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-2.2.0.tgz",
+            "integrity": "sha512-mR9PRYdO9L0usFtGcbFih7hqgi9Ky3y95QM22VEzjrX+Tktf0L0gkJP3XYwxMQRTxc6x4FBJzYw2UY+dGn4RrQ==",
+            "license": "ISC",
+            "peerDependencies": {
+                "react": ">= 16",
+                "react-dom": ">= 16"
+            }
+        },
+        "packages/bot-web-ui/node_modules/@deriv-com/quill-ui/node_modules/@headlessui/react": {
+            "version": "1.7.18",
+            "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.18.tgz",
+            "integrity": "sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/react-virtual": "^3.0.0-beta.60",
+                "client-only": "^0.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "react": "^16 || ^17 || ^18",
+                "react-dom": "^16 || ^17 || ^18"
+            }
+        },
+        "packages/bot-web-ui/node_modules/@deriv-com/quill-ui/node_modules/react-tiny-popover": {
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/react-tiny-popover/-/react-tiny-popover-8.1.4.tgz",
+            "integrity": "sha512-rHNAosGfUwlkOQeTJ+fCX/lHUOuMmgQZVhtRBnU9DqAONgltSv1QIZHeG1FGvZIGg7y7wbV4H6wriDuiSssIfQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "packages/bot-web-ui/node_modules/@deriv-com/quill-ui/node_modules/usehooks-ts": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.0.tgz",
+            "integrity": "sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==",
+            "license": "MIT",
+            "dependencies": {
+                "lodash.debounce": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=16.15.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0  || ^17 || ^18"
+            }
+        },
+        "packages/bot-web-ui/node_modules/@semantic-release/release-notes-generator": {
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.0.1.tgz",
+            "integrity": "sha512-K0w+5220TM4HZTthE5dDpIuFrnkN1NfTGPidJFm04ULT1DEZ9WG89VNXN7F0c+6nMEpWgqmPvb7vY7JkB2jyyA==",
+            "license": "MIT",
+            "dependencies": {
+                "conventional-changelog-angular": "^8.0.0",
+                "conventional-changelog-writer": "^8.0.0",
+                "conventional-commits-filter": "^5.0.0",
+                "conventional-commits-parser": "^6.0.0",
+                "debug": "^4.0.0",
+                "get-stream": "^7.0.0",
+                "import-from-esm": "^1.0.3",
+                "into-stream": "^7.0.0",
+                "lodash-es": "^4.17.21",
+                "read-package-up": "^11.0.0"
+            },
+            "engines": {
+                "node": ">=20.8.1"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=20.1.0"
+            }
+        },
+        "packages/bot-web-ui/node_modules/conventional-changelog-angular": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
+            "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
+            "license": "ISC",
+            "dependencies": {
+                "compare-func": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/bot-web-ui/node_modules/conventional-changelog-writer": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.0.0.tgz",
+            "integrity": "sha512-TQcoYGRatlAnT2qEWDON/XSfnVG38JzA7E0wcGScu7RElQBkg9WWgZd1peCWFcWDh1xfb2CfsrcvOn1bbSzztA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/semver": "^7.5.5",
+                "conventional-commits-filter": "^5.0.0",
+                "handlebars": "^4.7.7",
+                "meow": "^13.0.0",
+                "semver": "^7.5.2"
+            },
+            "bin": {
+                "conventional-changelog-writer": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/bot-web-ui/node_modules/conventional-commits-filter": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+            "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/bot-web-ui/node_modules/conventional-commits-parser": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.0.0.tgz",
+            "integrity": "sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==",
+            "license": "MIT",
+            "dependencies": {
+                "meow": "^13.0.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "packages/bot-web-ui/node_modules/json5": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
@@ -50857,6 +51045,43 @@
             },
             "engines": {
                 "node": ">=4.0.0"
+            }
+        },
+        "packages/bot-web-ui/node_modules/meow": {
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+            "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/bot-web-ui/node_modules/semver": {
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/bot-web-ui/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "packages/cashier": {
@@ -51147,7 +51372,7 @@
                 "@datadog/browser-rum": "^5.11.0",
                 "@deriv-com/analytics": "1.26.2",
                 "@deriv-com/quill-tokens": "2.0.4",
-                "@deriv-com/quill-ui": "1.21.0",
+                "@deriv-com/quill-ui": "1.24.0",
                 "@deriv-com/translations": "1.3.9",
                 "@deriv-com/ui": "1.36.4",
                 "@deriv-com/utils": "^0.0.36",
@@ -51270,10 +51495,214 @@
                 "node": "18.x"
             }
         },
+        "packages/core/node_modules/@deriv-com/quill-ui": {
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@deriv-com/quill-ui/-/quill-ui-1.24.0.tgz",
+            "integrity": "sha512-xzsnaX06RcqNV27kpvvSJOq93Nbho/W+Ms3DkyLNpctJK8dz+RCm+1rGCFwpxaQkeXCtRIMtTIR+k2lYzaHpVw==",
+            "dependencies": {
+                "@deriv-com/quill-tokens": "^2.0.13",
+                "@deriv/quill-icons": "^2.2.0",
+                "@headlessui/react": "1.7.18",
+                "dayjs": "^1.11.11",
+                "react-calendar": "^5.0.0",
+                "react-number-format": "^5.4.0",
+                "react-swipeable": "^6.2.1",
+                "react-tiny-popover": "^8.0.4",
+                "react-transition-group": "4.4.2",
+                "usehooks-ts": "^3.0.2",
+                "uuid": "^9.0.1"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-linux-x64-gnu": "^4.22.4"
+            }
+        },
+        "packages/core/node_modules/@deriv-com/quill-ui/node_modules/@deriv-com/quill-tokens": {
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/@deriv-com/quill-tokens/-/quill-tokens-2.0.13.tgz",
+            "integrity": "sha512-TMzgQkwCcg/wuiXMYfWoI9RxQsmDJIljdYxmvePvLsMOl43eyIo3PVGy0sTMsjlZJUzh8G0UzyF1tLBdpy3URA==",
+            "license": "ISC",
+            "dependencies": {
+                "@semantic-release/changelog": "^6.0.3",
+                "@semantic-release/github": "^10.0.4",
+                "@semantic-release/npm": "^12.0.1",
+                "@semantic-release/release-notes-generator": "^14.0.1",
+                "@types/lodash": "^4.14.197",
+                "lodash": "^4.17.21",
+                "remove": "^0.1.5"
+            }
+        },
+        "packages/core/node_modules/@deriv-com/quill-ui/node_modules/@deriv/quill-icons": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-2.2.0.tgz",
+            "integrity": "sha512-mR9PRYdO9L0usFtGcbFih7hqgi9Ky3y95QM22VEzjrX+Tktf0L0gkJP3XYwxMQRTxc6x4FBJzYw2UY+dGn4RrQ==",
+            "license": "ISC",
+            "peerDependencies": {
+                "react": ">= 16",
+                "react-dom": ">= 16"
+            }
+        },
+        "packages/core/node_modules/@deriv-com/quill-ui/node_modules/@headlessui/react": {
+            "version": "1.7.18",
+            "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.18.tgz",
+            "integrity": "sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/react-virtual": "^3.0.0-beta.60",
+                "client-only": "^0.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "react": "^16 || ^17 || ^18",
+                "react-dom": "^16 || ^17 || ^18"
+            }
+        },
+        "packages/core/node_modules/@deriv-com/quill-ui/node_modules/react-tiny-popover": {
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/react-tiny-popover/-/react-tiny-popover-8.1.4.tgz",
+            "integrity": "sha512-rHNAosGfUwlkOQeTJ+fCX/lHUOuMmgQZVhtRBnU9DqAONgltSv1QIZHeG1FGvZIGg7y7wbV4H6wriDuiSssIfQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "packages/core/node_modules/@deriv-com/quill-ui/node_modules/usehooks-ts": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.0.tgz",
+            "integrity": "sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==",
+            "license": "MIT",
+            "dependencies": {
+                "lodash.debounce": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=16.15.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0  || ^17 || ^18"
+            }
+        },
+        "packages/core/node_modules/@semantic-release/release-notes-generator": {
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.0.1.tgz",
+            "integrity": "sha512-K0w+5220TM4HZTthE5dDpIuFrnkN1NfTGPidJFm04ULT1DEZ9WG89VNXN7F0c+6nMEpWgqmPvb7vY7JkB2jyyA==",
+            "license": "MIT",
+            "dependencies": {
+                "conventional-changelog-angular": "^8.0.0",
+                "conventional-changelog-writer": "^8.0.0",
+                "conventional-commits-filter": "^5.0.0",
+                "conventional-commits-parser": "^6.0.0",
+                "debug": "^4.0.0",
+                "get-stream": "^7.0.0",
+                "import-from-esm": "^1.0.3",
+                "into-stream": "^7.0.0",
+                "lodash-es": "^4.17.21",
+                "read-package-up": "^11.0.0"
+            },
+            "engines": {
+                "node": ">=20.8.1"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=20.1.0"
+            }
+        },
+        "packages/core/node_modules/conventional-changelog-angular": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
+            "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
+            "license": "ISC",
+            "dependencies": {
+                "compare-func": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/core/node_modules/conventional-changelog-writer": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.0.0.tgz",
+            "integrity": "sha512-TQcoYGRatlAnT2qEWDON/XSfnVG38JzA7E0wcGScu7RElQBkg9WWgZd1peCWFcWDh1xfb2CfsrcvOn1bbSzztA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/semver": "^7.5.5",
+                "conventional-commits-filter": "^5.0.0",
+                "handlebars": "^4.7.7",
+                "meow": "^13.0.0",
+                "semver": "^7.5.2"
+            },
+            "bin": {
+                "conventional-changelog-writer": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/core/node_modules/conventional-commits-filter": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+            "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/core/node_modules/conventional-commits-parser": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.0.0.tgz",
+            "integrity": "sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==",
+            "license": "MIT",
+            "dependencies": {
+                "meow": "^13.0.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "packages/core/node_modules/js-cookie": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
             "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+        },
+        "packages/core/node_modules/meow": {
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+            "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/core/node_modules/semver": {
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/core/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
         },
         "packages/hooks": {
             "name": "@deriv/hooks",
@@ -51661,7 +52090,7 @@
             "dependencies": {
                 "@deriv-com/analytics": "1.26.2",
                 "@deriv-com/quill-tokens": "2.0.4",
-                "@deriv-com/quill-ui": "1.21.0",
+                "@deriv-com/quill-ui": "1.24.0",
                 "@deriv-com/ui": "1.36.4",
                 "@deriv-com/utils": "^0.0.36",
                 "@deriv/api-types": "1.0.172",
@@ -51755,6 +52184,210 @@
             },
             "engines": {
                 "node": "18.x"
+            }
+        },
+        "packages/trader/node_modules/@deriv-com/quill-ui": {
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@deriv-com/quill-ui/-/quill-ui-1.24.0.tgz",
+            "integrity": "sha512-xzsnaX06RcqNV27kpvvSJOq93Nbho/W+Ms3DkyLNpctJK8dz+RCm+1rGCFwpxaQkeXCtRIMtTIR+k2lYzaHpVw==",
+            "dependencies": {
+                "@deriv-com/quill-tokens": "^2.0.13",
+                "@deriv/quill-icons": "^2.2.0",
+                "@headlessui/react": "1.7.18",
+                "dayjs": "^1.11.11",
+                "react-calendar": "^5.0.0",
+                "react-number-format": "^5.4.0",
+                "react-swipeable": "^6.2.1",
+                "react-tiny-popover": "^8.0.4",
+                "react-transition-group": "4.4.2",
+                "usehooks-ts": "^3.0.2",
+                "uuid": "^9.0.1"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-linux-x64-gnu": "^4.22.4"
+            }
+        },
+        "packages/trader/node_modules/@deriv-com/quill-ui/node_modules/@deriv-com/quill-tokens": {
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/@deriv-com/quill-tokens/-/quill-tokens-2.0.13.tgz",
+            "integrity": "sha512-TMzgQkwCcg/wuiXMYfWoI9RxQsmDJIljdYxmvePvLsMOl43eyIo3PVGy0sTMsjlZJUzh8G0UzyF1tLBdpy3URA==",
+            "license": "ISC",
+            "dependencies": {
+                "@semantic-release/changelog": "^6.0.3",
+                "@semantic-release/github": "^10.0.4",
+                "@semantic-release/npm": "^12.0.1",
+                "@semantic-release/release-notes-generator": "^14.0.1",
+                "@types/lodash": "^4.14.197",
+                "lodash": "^4.17.21",
+                "remove": "^0.1.5"
+            }
+        },
+        "packages/trader/node_modules/@deriv-com/quill-ui/node_modules/@deriv/quill-icons": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-2.2.0.tgz",
+            "integrity": "sha512-mR9PRYdO9L0usFtGcbFih7hqgi9Ky3y95QM22VEzjrX+Tktf0L0gkJP3XYwxMQRTxc6x4FBJzYw2UY+dGn4RrQ==",
+            "license": "ISC",
+            "peerDependencies": {
+                "react": ">= 16",
+                "react-dom": ">= 16"
+            }
+        },
+        "packages/trader/node_modules/@deriv-com/quill-ui/node_modules/@headlessui/react": {
+            "version": "1.7.18",
+            "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.18.tgz",
+            "integrity": "sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/react-virtual": "^3.0.0-beta.60",
+                "client-only": "^0.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "react": "^16 || ^17 || ^18",
+                "react-dom": "^16 || ^17 || ^18"
+            }
+        },
+        "packages/trader/node_modules/@deriv-com/quill-ui/node_modules/react-tiny-popover": {
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/react-tiny-popover/-/react-tiny-popover-8.1.4.tgz",
+            "integrity": "sha512-rHNAosGfUwlkOQeTJ+fCX/lHUOuMmgQZVhtRBnU9DqAONgltSv1QIZHeG1FGvZIGg7y7wbV4H6wriDuiSssIfQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "packages/trader/node_modules/@deriv-com/quill-ui/node_modules/usehooks-ts": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.0.tgz",
+            "integrity": "sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==",
+            "license": "MIT",
+            "dependencies": {
+                "lodash.debounce": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=16.15.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0  || ^17 || ^18"
+            }
+        },
+        "packages/trader/node_modules/@semantic-release/release-notes-generator": {
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.0.1.tgz",
+            "integrity": "sha512-K0w+5220TM4HZTthE5dDpIuFrnkN1NfTGPidJFm04ULT1DEZ9WG89VNXN7F0c+6nMEpWgqmPvb7vY7JkB2jyyA==",
+            "license": "MIT",
+            "dependencies": {
+                "conventional-changelog-angular": "^8.0.0",
+                "conventional-changelog-writer": "^8.0.0",
+                "conventional-commits-filter": "^5.0.0",
+                "conventional-commits-parser": "^6.0.0",
+                "debug": "^4.0.0",
+                "get-stream": "^7.0.0",
+                "import-from-esm": "^1.0.3",
+                "into-stream": "^7.0.0",
+                "lodash-es": "^4.17.21",
+                "read-package-up": "^11.0.0"
+            },
+            "engines": {
+                "node": ">=20.8.1"
+            },
+            "peerDependencies": {
+                "semantic-release": ">=20.1.0"
+            }
+        },
+        "packages/trader/node_modules/conventional-changelog-angular": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
+            "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
+            "license": "ISC",
+            "dependencies": {
+                "compare-func": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/trader/node_modules/conventional-changelog-writer": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.0.0.tgz",
+            "integrity": "sha512-TQcoYGRatlAnT2qEWDON/XSfnVG38JzA7E0wcGScu7RElQBkg9WWgZd1peCWFcWDh1xfb2CfsrcvOn1bbSzztA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/semver": "^7.5.5",
+                "conventional-commits-filter": "^5.0.0",
+                "handlebars": "^4.7.7",
+                "meow": "^13.0.0",
+                "semver": "^7.5.2"
+            },
+            "bin": {
+                "conventional-changelog-writer": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/trader/node_modules/conventional-commits-filter": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+            "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/trader/node_modules/conventional-commits-parser": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.0.0.tgz",
+            "integrity": "sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==",
+            "license": "MIT",
+            "dependencies": {
+                "meow": "^13.0.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/trader/node_modules/meow": {
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+            "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/trader/node_modules/semver": {
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/trader/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "packages/translations": {

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -35,7 +35,7 @@
         "@deriv-com/utils": "^0.0.36",
         "@deriv-com/ui": "1.36.4",
         "@deriv/api": "^1.0.0",
-        "@deriv-com/quill-ui": "1.21.0",
+        "@deriv-com/quill-ui": "1.24.0",
         "@deriv/components": "^1.0.0",
         "@deriv/hooks": "^1.0.0",
         "@deriv/quill-icons": "1.23.3",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -71,7 +71,7 @@
         "webpack-cli": "^5.1.4"
     },
     "dependencies": {
-        "@deriv-com/quill-ui": "1.21.0",
+        "@deriv-com/quill-ui": "1.24.0",
         "@deriv-com/ui": "1.36.4",
         "@deriv/api": "^1.0.0",
         "@deriv/api-types": "1.0.172",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -97,7 +97,7 @@
         "@datadog/browser-rum": "^5.11.0",
         "@deriv-com/analytics": "1.26.2",
         "@deriv-com/quill-tokens": "2.0.4",
-        "@deriv-com/quill-ui": "1.21.0",
+        "@deriv-com/quill-ui": "1.24.0",
         "@deriv-com/translations": "1.3.9",
         "@deriv-com/ui": "1.36.4",
         "@deriv-com/utils": "^0.0.36",

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -90,7 +90,7 @@
     "dependencies": {
         "@deriv-com/analytics": "1.26.2",
         "@deriv-com/quill-tokens": "2.0.4",
-        "@deriv-com/quill-ui": "1.21.0",
+        "@deriv-com/quill-ui": "1.24.0",
         "@deriv-com/utils": "^0.0.36",
         "@deriv-com/ui": "1.36.4",
         "@deriv/api-types": "1.0.172",


### PR DESCRIPTION
## Changes:

This chore updates the `quill-ui` library to version 1.24.0, ensuring compatibility with the latest features and improvements.

1. Version Upgrade: Bump `quill-ui` to 1.24.0 to include new updates and fixes.
2. Compatibility Check: Verify seamless integration with existing components.
3. Improved Stability: Leverage the enhancements and bug fixes provided in the updated version.

This update keeps the project aligned with the latest `quill-ui` advancements.

