### PR TITLE
[FEQ] george / FEQ-2702 / Improve Coverall workflow time execution. Part 2. Adding caching npm packages

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -6,6 +6,9 @@ jobs:
   test:
     name: Run tests in parallel
     runs-on: Runner_16cores_Deriv-app
+    permissions:
+      contents: read
+      actions: read
     strategy:
       matrix:
         shard: [1,2,3,4,5,6,7,8,9,10]

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,7 +1,4 @@
 on: 
-  push:
-    branches:
-      - master
   pull_request:
     types: [opened, synchronize, edited]    
 name: Reporter
@@ -18,7 +15,16 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Setup Node
         uses: './.github/actions/setup_node'
-      - name: Install dependencies
+      - name: Cache node modules
+        id: cache-npm
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: node_modules-cache-${{ hashFiles('package-lock.json', 'packages/*/package.json') }}
+      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        name: Install dependencies
         uses: "./.github/actions/npm_install_from_cache"
       - name: Build components package
         working-directory: packages/components
@@ -28,7 +34,7 @@ jobs:
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949
         with:
-          flag-name: ${{ matrix.shard}}
+          flag-name: ${{ matrix.shard }}
           parallel: true
 
   finish:


### PR DESCRIPTION
## Changes:

# Coveralls Workflow Improvements

## Key Changes

### 1. Caching Node Modules:

-   Added a step to cache `node_modules` to speed up the workflow by avoiding repeated installations of dependencies.

-   Utilized the `actions/cache@v4` action to cache the  `node_modules` directory and any `node_modules` within  `packages/*`.

-   The cache key is generated using the hash of  `package-lock.json` and `packages/*/package.json` files to ensure the cache is updated when dependencies change.

### 2. Conditional Dependency Installation:

-   Introduced a conditional step to install dependencies only if the cache is not hit `(cache-hit != 'true')`.

### 3. Removing trigger on master push:

-   Removed trigger on master push because we already running tests in [Deriv App Release to Test environment Workflow](https://github.com/deriv-com/deriv-app/actions/runs/12112309040/workflow)

> Note: These changes aim to optimize the workflow by reducing the time spent on installing dependencies, leveraging caching to reuse previously installed modules.
