### PR TITLE
fix: improve report  push notification on click 

### DIFF
--- a/packages/bot-web-ui/src/stores/run-panel-store.ts
+++ b/packages/bot-web-ui/src/stores/run-panel-store.ts
@@ -13,6 +13,7 @@ import GTM from 'Utils/gtm';
 import { helpers } from 'Utils/store-helpers';
 import { TDbot } from 'Types';
 import RootStore from './root-store';
+import { getSelectedTradeType } from '@deriv/bot-skeleton/src/scratch/utils';
 
 export type TContractState = {
     buy?: Buy;
@@ -137,7 +138,11 @@ export default class RunPanelStore {
         if (show_bot_stop_message)
             botNotification(notification_message.bot_stop, {
                 label: localize('Reports'),
-                onClick: () => (window.location.href = routes.reports),
+                onClick: () => {
+                    const contract_type = getSelectedTradeType();
+                    sessionStorage.setItem('contract_type_bots', contract_type);
+                    window.location.href = routes.reports;
+                },
             });
     };
 

--- a/packages/reports/src/Containers/open-positions.tsx
+++ b/packages/reports/src/Containers/open-positions.tsx
@@ -189,11 +189,32 @@ const OpenPositions = observer(({ component_icon, ...props }: TOpenPositions) =>
     const [has_multiplier_contract, setHasMultiplierContract] = React.useState(false);
     const { isDesktop } = useDevice();
     const previous_active_positions = usePrevious(active_positions);
-    const contract_types = [
-        { text: localize('Options'), value: 'options', is_default: !is_multiplier && !is_accumulator },
-        { text: localize('Multipliers'), value: 'multipliers', is_default: is_multiplier },
-        { text: localize('Accumulators'), value: 'accumulators', is_default: is_accumulator },
-    ];
+
+    const generateContractTypes = () => {
+        const contract_type_bot = sessionStorage.getItem('contract_type_bots');
+
+        if (!contract_type_bot) {
+            return [
+                { text: localize('Options'), value: 'options', is_default: !is_multiplier && !is_accumulator },
+                { text: localize('Multipliers'), value: 'multipliers', is_default: is_multiplier },
+                { text: localize('Accumulators'), value: 'accumulators', is_default: is_accumulator },
+            ];
+        }
+
+        const is_multiplier_bot = contract_type_bot === 'trade_definition_multiplier';
+        const is_accumulator_bot = contract_type_bot === 'trade_definition_accumulator';
+
+        const contract_types = [
+            { text: localize('Options'), value: 'options', is_default: !is_multiplier_bot && !is_accumulator_bot },
+            { text: localize('Multipliers'), value: 'multipliers', is_default: is_multiplier_bot },
+            { text: localize('Accumulators'), value: 'accumulators', is_default: is_accumulator_bot },
+        ];
+        sessionStorage.removeItem('contract_type_bots');
+        return contract_types;
+    };
+
+    const contract_types = generateContractTypes();
+
     const [contract_type_value, setContractTypeValue] = React.useState(
         contract_types.find(type => type.is_default)?.value || 'options'
     );


### PR DESCRIPTION
When clicking on the Reports link, the page redirects to reports/positions. However, the redirection does not carry the correct trade type. For example, if the user clicks on a Reports link associated with Accumulators, the page still redirects to reports/positions with the default trade type set to Options. This results in an error message stating "No contract positions", which can be misleading for the user.
Expected Behavior:
The redirection to reports/positions should reflect the context of the selected trade type. For instance:
If the user clicks on a Reports link for Accumulators, the reports/positions page should display Accumulators as the selected trade type and load relevant contract positions (if available).
Similarly, if the user clicks on a link associated with Multipliers, the page should display Multipliers as the selected trade type.


