### PR TITLE
fix: add push trigger to master for coverall workflow

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,6 +1,9 @@
 name: Reporter
 
-on: 
+on:
+  push:
+    branches:
+      - master 
   pull_request:
     types: [opened, synchronize, edited]
     


### PR DESCRIPTION
## Changes:

- add push trigger to master branch for coveralls workflow to avoid [`drifted` builds](https://docs.coveralls.io/build-types#common-issue-drifted-builds--two-dot-vs-three-dot-diff-comparisons-in-coverage-reports) and fix coverall reports appearance in pull requests

### Screenshots:

Please provide some screenshots of the change.
