### PR TITLE
Rupato/BOT-2436/fix: for currency on trade definition block

### DIFF
--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
@@ -522,7 +522,7 @@ Blockly.Blocks.trade_definition_tradeoptions = {
     setCurrency() {
         const currency_field = this.getField('CURRENCY_LIST');
         const { currency } = DBotStore.instance.client;
-        currency_field?.setText(getCurrencyDisplayCode(currency));
+        currency_field.setValue(getCurrencyDisplayCode(currency));
     },
     restricted_parents: ['trade_definition'],
     getRequiredValueInputs() {

--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
@@ -522,7 +522,7 @@ Blockly.Blocks.trade_definition_tradeoptions = {
     setCurrency() {
         const currency_field = this.getField('CURRENCY_LIST');
         const { currency } = DBotStore.instance.client;
-        currency_field.setValue(getCurrencyDisplayCode(currency));
+        currency_field?.setValue(getCurrencyDisplayCode(currency));
     },
     restricted_parents: ['trade_definition'],
     getRequiredValueInputs() {


### PR DESCRIPTION
Fixed currecy on trade definition block. by updating to the new blockly method called setValue
