### PR TITLE
Rupato/BOT-2436/fix: updated blockly method

### DIFF
--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/accumulator_take_profit.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/accumulator_take_profit.js
@@ -1,7 +1,7 @@
 import { localize } from '@deriv/translations';
 import { getCurrencyDisplayCode } from '@deriv/shared';
 import { config } from '../../../../constants/config';
-import { excludeOptionFromContextMenu, modifyContextMenu } from '../../../utils';
+import { excludeOptionFromContextMenu, modifyContextMenu, setCurrency } from '../../../utils';
 
 const description = localize(
     'Your contract is closed automatically when your profit is more than or equals to this amount. This block can only be used with the accumulator trade type.'
@@ -52,7 +52,7 @@ Blockly.Blocks.accumulator_take_profit = {
             (event.type === Blockly.Events.BLOCK_CREATE && event.ids.includes(this.id)) ||
             (event.type === Blockly.Events.BLOCK_DRAG && !event.isStart)
         ) {
-            this.setCurrency();
+            setCurrency(this);
         }
     },
     customContextMenu(menu) {
@@ -61,7 +61,6 @@ Blockly.Blocks.accumulator_take_profit = {
         modifyContextMenu(menu);
     },
     restricted_parents: ['trade_definition_accumulator'],
-    setCurrency: Blockly.Blocks.trade_definition_tradeoptions.setCurrency,
     getRequiredValueInputs() {
         const field_input = this.getInput('AMOUNT');
         if (field_input.connection.targetBlock()) {

--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/accumulator_take_profit.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/accumulator_take_profit.js
@@ -50,7 +50,8 @@ Blockly.Blocks.accumulator_take_profit = {
         }
         if (
             (event.type === Blockly.Events.BLOCK_CREATE && event.ids.includes(this.id)) ||
-            (event.type === Blockly.Events.BLOCK_DRAG && !event.isStart)
+            (event.type === Blockly.Events.BLOCK_DRAG && !event.isStart) ||
+            (event.type === Blockly.Events.BLOCK_CHANGE && !event.isStart)
         ) {
             setCurrency(this);
         }

--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/multiplier_stop_loss.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/multiplier_stop_loss.js
@@ -1,7 +1,7 @@
 import { localize } from '@deriv/translations';
 import { getCurrencyDisplayCode } from '@deriv/shared';
 import { config } from '../../../../constants/config';
-import { modifyContextMenu } from '../../../utils';
+import { modifyContextMenu, setCurrency } from '../../../utils';
 
 const description = localize(
     'Your contract is closed automatically when your loss is more than or equals to this amount. This block can only be used with the multipliers trade type.'
@@ -55,11 +55,10 @@ Blockly.Blocks.multiplier_stop_loss = {
             (event.type === Blockly.Events.BLOCK_CREATE && event.ids.includes(this.id)) ||
             (event.type === Blockly.Events.BLOCK_DRAG && !event.isStart)
         ) {
-            this.setCurrency();
+            setCurrency(this);
         }
     },
     restricted_parents: ['trade_definition_multiplier'],
-    setCurrency: Blockly.Blocks.trade_definition_tradeoptions.setCurrency,
     getRequiredValueInputs() {
         const field_input = this.getInput('AMOUNT');
         if (field_input.connection.targetBlock()) {

--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/multiplier_stop_loss.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/multiplier_stop_loss.js
@@ -53,7 +53,8 @@ Blockly.Blocks.multiplier_stop_loss = {
         }
         if (
             (event.type === Blockly.Events.BLOCK_CREATE && event.ids.includes(this.id)) ||
-            (event.type === Blockly.Events.BLOCK_DRAG && !event.isStart)
+            (event.type === Blockly.Events.BLOCK_DRAG && !event.isStart) ||
+            (event.type === Blockly.Events.BLOCK_CHANGE && !event.isStart)
         ) {
             setCurrency(this);
         }

--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/multiplier_take_profit.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/multiplier_take_profit.js
@@ -1,7 +1,7 @@
 import { localize } from '@deriv/translations';
 import { getCurrencyDisplayCode } from '@deriv/shared';
 import { config } from '../../../../constants/config';
-import { modifyContextMenu } from '../../../utils';
+import { modifyContextMenu, setCurrency } from '../../../utils';
 
 const description = localize(
     'Your contract is closed automatically when your profit is more than or equals to this amount. This block can only be used with the multipliers trade type.'
@@ -55,11 +55,10 @@ Blockly.Blocks.multiplier_take_profit = {
             (event.type === Blockly.Events.BLOCK_CREATE && event.ids.includes(this.id)) ||
             (event.type === Blockly.Events.BLOCK_DRAG && !event.isStart)
         ) {
-            this.setCurrency();
+            setCurrency(this);
         }
     },
     restricted_parents: ['trade_definition_multiplier'],
-    setCurrency: Blockly.Blocks.trade_definition_tradeoptions.setCurrency,
     getRequiredValueInputs() {
         const field_input = this.getInput('AMOUNT');
         if (field_input.connection.targetBlock()) {

--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/multiplier_take_profit.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/multiplier_take_profit.js
@@ -53,7 +53,8 @@ Blockly.Blocks.multiplier_take_profit = {
         }
         if (
             (event.type === Blockly.Events.BLOCK_CREATE && event.ids.includes(this.id)) ||
-            (event.type === Blockly.Events.BLOCK_DRAG && !event.isStart)
+            (event.type === Blockly.Events.BLOCK_DRAG && !event.isStart) ||
+            (event.type === Blockly.Events.BLOCK_CHANGE && !event.isStart)
         ) {
             setCurrency(this);
         }

--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_accumulator.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_accumulator.js
@@ -1,7 +1,7 @@
 import { localize } from '@deriv/translations';
 import { getCurrencyDisplayCode, getDecimalPlaces } from '@deriv/shared';
 import DBotStore from '../../../dbot-store';
-import { modifyContextMenu, runGroupedEvents, runIrreversibleEvents } from '../../../utils';
+import { modifyContextMenu, runGroupedEvents, runIrreversibleEvents, setCurrency } from '../../../utils';
 import { config } from '../../../../constants/config';
 import ApiHelpers from '../../../../services/api/api-helpers';
 import { handleProposalRequestForAccumulators } from '../../../accumulators-proposal-handler';
@@ -126,7 +126,6 @@ Blockly.Blocks.trade_definition_accumulator = {
         const is_load_event = /^dbot-load/.test(event.group);
 
         if (event.type === Blockly.Events.BLOCK_CREATE && event.ids.includes(this.id)) {
-            this.setCurrency();
             if (is_load_event) {
                 // Do NOT touch any values when a strategy is being loaded.
                 this.updateAccumulatorInput(false);
@@ -137,6 +136,7 @@ Blockly.Blocks.trade_definition_accumulator = {
         }
 
         if (event.type === Blockly.Events.BLOCK_CHANGE) {
+            setCurrency(this);
             this.validateBlocksInStatement();
             if (is_load_event) {
                 if (event.name === 'TRADETYPE_LIST') {
@@ -158,7 +158,6 @@ Blockly.Blocks.trade_definition_accumulator = {
         }
 
         if (event.type === Blockly.Events.BLOCK_DRAG && !event.isStart) {
-            this.setCurrency();
             this.validateBlocksInStatement();
             if (event.blockId === this.id) {
                 // Ensure this block is populated after initial drag from flyout.
@@ -237,7 +236,6 @@ Blockly.Blocks.trade_definition_accumulator = {
     customContextMenu(menu) {
         modifyContextMenu(menu);
     },
-    setCurrency: Blockly.Blocks.trade_definition_tradeoptions.setCurrency,
     restricted_parents: ['trade_definition'],
     getRequiredValueInputs() {
         return {

--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_multiplier.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_multiplier.js
@@ -1,7 +1,7 @@
 import { localize } from '@deriv/translations';
 import { getCurrencyDisplayCode, getDecimalPlaces } from '@deriv/shared';
 import DBotStore from '../../../dbot-store';
-import { runGroupedEvents, runIrreversibleEvents, modifyContextMenu } from '../../../utils';
+import { runGroupedEvents, runIrreversibleEvents, modifyContextMenu, setCurrency } from '../../../utils';
 import { config } from '../../../../constants/config';
 import ApiHelpers from '../../../../services/api/api-helpers';
 
@@ -134,7 +134,6 @@ Blockly.Blocks.trade_definition_multiplier = {
         const is_load_event = /^dbot-load/.test(event.group);
 
         if (event.type === Blockly.Events.BLOCK_CREATE && event.ids.includes(this.id)) {
-            this.setCurrency();
             if (is_load_event) {
                 // Do NOT touch any values when a strategy is being loaded.
                 this.updateMultiplierInput(false);
@@ -146,6 +145,7 @@ Blockly.Blocks.trade_definition_multiplier = {
 
         if (event.type === Blockly.Events.BLOCK_CHANGE) {
             this.validateBlocksInStatement();
+            setCurrency(this);
             if (is_load_event) {
                 if (event.name === 'TRADETYPE_LIST') {
                     this.updateMultiplierInput(false);
@@ -166,7 +166,6 @@ Blockly.Blocks.trade_definition_multiplier = {
         }
 
         if (event.type === Blockly.Events.BLOCK_DRAG && !event.isStart) {
-            this.setCurrency();
             this.validateBlocksInStatement();
             if (event.blockId === this.id) {
                 // Ensure this block is populated after initial drag from flyout.
@@ -245,7 +244,6 @@ Blockly.Blocks.trade_definition_multiplier = {
     customContextMenu(menu) {
         modifyContextMenu(menu);
     },
-    setCurrency: Blockly.Blocks.trade_definition_tradeoptions.setCurrency,
     restricted_parents: ['trade_definition'],
     getRequiredValueInputs() {
         return {

--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
@@ -522,7 +522,7 @@ Blockly.Blocks.trade_definition_tradeoptions = {
     setCurrency() {
         const currency_field = this.getField('CURRENCY_LIST');
         const { currency } = DBotStore.instance.client;
-        currency_field?.setText(getCurrencyDisplayCode(currency));
+        currency_field?.setValue(getCurrencyDisplayCode(currency));
     },
     restricted_parents: ['trade_definition'],
     getRequiredValueInputs() {

--- a/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
+++ b/packages/bot-skeleton/src/scratch/blocks/Binary/Trade Definition/trade_definition_tradeoptions.js
@@ -1,7 +1,7 @@
 import { localize } from '@deriv/translations';
 import { getCurrencyDisplayCode, getDecimalPlaces } from '@deriv/shared';
 import DBotStore from '../../../dbot-store';
-import { runIrreversibleEvents, runGroupedEvents, modifyContextMenu } from '../../../utils';
+import { runIrreversibleEvents, runGroupedEvents, modifyContextMenu, setCurrency } from '../../../utils';
 import { config } from '../../../../constants/config';
 import ApiHelpers from '../../../../services/api/api-helpers';
 
@@ -118,7 +118,7 @@ Blockly.Blocks.trade_definition_tradeoptions = {
             (event.type === Blockly.Events.BLOCK_CREATE && event.ids.includes(this.id)) ||
             (event.type === Blockly.Events.BLOCK_DRAG && !event.isStart)
         ) {
-            this.setCurrency();
+            setCurrency(this);
             this.updateAmountLimits();
         }
 
@@ -518,11 +518,6 @@ Blockly.Blocks.trade_definition_tradeoptions = {
         container.setAttribute('has_prediction', !!this.getInput('PREDICTION'));
 
         return container;
-    },
-    setCurrency() {
-        const currency_field = this.getField('CURRENCY_LIST');
-        const { currency } = DBotStore.instance.client;
-        currency_field?.setValue(getCurrencyDisplayCode(currency));
     },
     restricted_parents: ['trade_definition'],
     getRequiredValueInputs() {

--- a/packages/bot-skeleton/src/scratch/utils/index.js
+++ b/packages/bot-skeleton/src/scratch/utils/index.js
@@ -10,6 +10,7 @@ import { LogTypes } from '../../constants/messages';
 import { error_message_map } from '../../utils/error-config';
 import { botNotification } from '@deriv/bot-web-ui/src/components/bot-notification/bot-notification';
 import { notification_message } from '@deriv/bot-web-ui/src/components/bot-notification/bot-notification-utils';
+import { getCurrencyDisplayCode } from '@deriv/shared';
 
 export const inject_workspace_options = {
     media: `${__webpack_public_path__}media/`,
@@ -720,4 +721,10 @@ export const evaluateExpression = value => {
     } catch (e) {
         return 'invalid_input';
     }
+};
+
+export const setCurrency = block_instance => {
+    const currency_field = block_instance.getField('CURRENCY_LIST');
+    const { currency } = DBotStore.instance.client;
+    currency_field?.setValue(getCurrencyDisplayCode(currency));
 };

--- a/packages/bot-web-ui/src/constants/quick-strategies/d_alembert.ts
+++ b/packages/bot-web-ui/src/constants/quick-strategies/d_alembert.ts
@@ -64,7 +64,7 @@ export const D_ALEMBERT: TDescriptionItem[] = [
     {
         type: 'media',
         src: getImageLocation('dalembert.svg'),
-        alt: localize("An example of D’Alembert's Grind strategy"),
+        alt: localize('An example of D’Alembert strategy'),
     },
     {
         type: 'text',

--- a/packages/bot-web-ui/src/stores/app-store.ts
+++ b/packages/bot-web-ui/src/stores/app-store.ts
@@ -5,6 +5,7 @@ import { ContentFlag, isEuResidenceWithOnlyVRTC, routes, showDigitalOptionsUnava
 import { TStores } from '@deriv/stores/types';
 import { localize } from '@deriv/translations';
 import RootStore from './root-store';
+import { setCurrency } from '@deriv/bot-skeleton/src/scratch/utils';
 
 export default class AppStore {
     root_store: RootStore;
@@ -254,7 +255,7 @@ export default class AppStore {
         // Syncs all trade options blocks' currency with the client's active currency.
         this.disposeCurrencyReaction = reaction(
             () => this.core.client.currency,
-            currency => {
+            () => {
                 if (!window.Blockly.derivWorkspace) return;
 
                 const trade_options_blocks = window.Blockly.derivWorkspace
@@ -267,7 +268,7 @@ export default class AppStore {
                             (b.isDescendantOf('trade_definition_multiplier') && b.category_ === 'trade_parameters')
                     );
 
-                trade_options_blocks.forEach(trade_options_block => trade_options_block.setCurrency(currency));
+                trade_options_blocks.forEach(trade_options_block => setCurrency(trade_options_block));
             }
         );
     };


### PR DESCRIPTION
Fixed currecy on trade definition block. by updating to the new blockly method called setValue