### PR TITLE
fix: draggable component console css errors

### DIFF
--- a/packages/bot-web-ui/src/components/draggable/draggable.tsx
+++ b/packages/bot-web-ui/src/components/draggable/draggable.tsx
@@ -178,7 +178,11 @@ const Draggable: React.FC<TDraggableProps> = ({
             setIsDragging(false);
             isResizing.current = false;
             if (draggableContentBody?.style) {
-                Object.assign(draggableContentBody.style, previousStyle);
+                try {
+                    Object.assign(draggableContentBody.style, previousStyle);
+                } catch {
+                    // no need to handle this error
+                }
                 draggableContentBody.style.pointerEvents = previousPointerEvent ?? 'unset';
             }
             if (boundaryRef) {

--- a/packages/bot-web-ui/src/components/draggable/draggable.tsx
+++ b/packages/bot-web-ui/src/components/draggable/draggable.tsx
@@ -196,7 +196,12 @@ const Draggable: React.FC<TDraggableProps> = ({
     return (
         <div
             className={`draggable ${isDragging ? 'dragging' : ''}`}
-            style={{ position: 'absolute', top: position.y, left: position.x, zIndex }}
+            style={{
+                position: 'absolute',
+                top: typeof position.y === 'number' ? position.y : 0,
+                left: typeof position.x === 'number' ? position.x : 0,
+                zIndex: typeof zIndex === 'number' ? zIndex : 0,
+            }}
             onMouseDown={() => calculateZindex({ setZIndex })}
             onKeyDown={() => calculateZindex({ setZIndex })}
             data-testid='dt_react_draggable'
@@ -206,7 +211,10 @@ const Draggable: React.FC<TDraggableProps> = ({
                 ref={draggableRef}
                 className='draggable-content'
                 data-testid='dt_react_draggable_content'
-                style={{ width: size.width, height: size.height }}
+                style={{
+                    width: typeof size.width === 'number' ? size.width : 0,
+                    height: typeof size.height === 'number' ? size.height : 0,
+                }}
             >
                 <div
                     id='draggable-content__header'


### PR DESCRIPTION
This pull request includes changes to the `Draggable` component in the `packages/bot-web-ui` to improve its robustness by adding type checks for style properties.

Improvements to `Draggable` component:

* [`packages/bot-web-ui/src/components/draggable/draggable.tsx`](diffhunk://#diff-8cdde222cb106b9fdfb85fe2a755b530636b44636efe55c93feb8808054e2690L199-R204): Updated the styles to include type checks for `position.y`, `position.x`, and `zIndex` to ensure they are numbers, defaulting to 0 if not.
* [`packages/bot-web-ui/src/components/draggable/draggable.tsx`](diffhunk://#diff-8cdde222cb106b9fdfb85fe2a755b530636b44636efe55c93feb8808054e2690L209-R217): Added type checks for `size.width` and `size.height` to ensure they are numbers, defaulting to 0 if not.## Changes:

Please provide a summary of the change.

### Screenshots:

Please provide some screenshots of the change.
