### PR TITLE
chore: adding network information to page view event

### DIFF
--- a/packages/core/src/App/Containers/Layout/app-contents.jsx
+++ b/packages/core/src/App/Containers/Layout/app-contents.jsx
@@ -59,6 +59,9 @@ const AppContents = observer(({ children }) => {
         Analytics.pageView(window.location.href, {
             loggedIn: is_logged_in,
             device_type: isMobile ? 'mobile' : 'desktop',
+            network_rtt: navigator?.connection?.rtt,
+            network_type: navigator?.connection?.effectiveType,
+            network_downlink: navigator?.connection?.downlink,
         });
         // react-hooks/exhaustive-deps
     }, [window.location.href]);


### PR DESCRIPTION
## Changes:

Adding network information (network type, network rtt, network downlink) on the page view event 

### Screenshots:

<img width="876" alt="Screenshot 2024-12-11 at 1 00 44 PM" src="https://github.com/user-attachments/assets/da6ac9d2-f444-4381-912b-a753fb48503f">
