### PR TITLE
Thisyahlen/fix: account switching

### DIFF
--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -1677,6 +1677,12 @@ export default class ClientStore extends BaseStore {
                 await this.fetchStatesList();
             }
             if (!this.is_virtual) await this.getLimits();
+
+            // This was set for the new callback page logic, once the user has logged in, we can remove the tokens and account1 from local storage since client.accounts is handling it already
+            if (localStorage.getItem('config.tokens') && localStorage.getItem('config.account1')) {
+                localStorage.removeItem('config.tokens');
+                localStorage.removeItem('config.account1');
+            }
         } else {
             this.resetMt5AccountListPopulation();
         }


### PR DESCRIPTION
## Changes:
Removed tokens and account1 from localStorage once user is logged in. 

config.tokens and config.account1 was set in localStorage in the callback page so that it doesnt affect legacy code. So once client store retrieves the tokens and account1 and set the `client.accounts`, we dont need config.tokens and account1 anymore. Therefore removing it
