### PR TITLE
DTRA-2471 / Kate / DND console error 

### DIFF
--- a/packages/trader/src/AppV2/Components/DraggableList/draggable-list.scss
+++ b/packages/trader/src/AppV2/Components/DraggableList/draggable-list.scss
@@ -54,7 +54,6 @@
             display: flex;
             flex-direction: column;
             padding: var(--core-spacing-500) 0;
-            overflow: auto;
         }
 
         &__item {

--- a/packages/trader/src/AppV2/Containers/Trade/trade-types-content.tsx
+++ b/packages/trader/src/AppV2/Containers/Trade/trade-types-content.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
-import { Button, Text, ActionSheet } from '@deriv-com/quill-ui';
+import clsx from 'clsx';
+
+import { Localize } from '@deriv/translations';
+import { ActionSheet, Button, Text } from '@deriv-com/quill-ui';
+
 import { DraggableList } from 'AppV2/Components/DraggableList';
 import { TradeTypeList } from 'AppV2/Components/TradeTypeList';
-import { Localize } from '@deriv/translations';
+
 import { TItem, TResultItem } from './trade-types';
 
 type TTradeTypesContent = {
@@ -52,7 +56,11 @@ const TradeTypesContent = ({
                 </Button>
             </div>
         </div>
-        <ActionSheet.Content className='trade-types-dialog__content'>
+        <ActionSheet.Content
+            className={clsx('trade-types-dialog__content', {
+                'trade-types-dialog__content--is_editing': is_editing,
+            })}
+        >
             {is_editing ? (
                 <DraggableList
                     categories={pinned_trade_types}

--- a/packages/trader/src/AppV2/Containers/Trade/trade-types-content.tsx
+++ b/packages/trader/src/AppV2/Containers/Trade/trade-types-content.tsx
@@ -56,11 +56,7 @@ const TradeTypesContent = ({
                 </Button>
             </div>
         </div>
-        <ActionSheet.Content
-            className={clsx('trade-types-dialog__content', {
-                'trade-types-dialog__content--is_editing': is_editing,
-            })}
-        >
+        <ActionSheet.Content className='trade-types-dialog__content'>
             {is_editing ? (
                 <DraggableList
                     categories={pinned_trade_types}

--- a/packages/trader/src/AppV2/Containers/Trade/trade-types.tsx
+++ b/packages/trader/src/AppV2/Containers/Trade/trade-types.tsx
@@ -1,19 +1,22 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import clsx from 'clsx';
+
 import { LabelPairedPresentationScreenSmRegularIcon } from '@deriv/quill-icons';
-import { useTraderStore } from 'Stores/useTraderStores';
-import { Button, Chip, Text, ActionSheet } from '@deriv-com/quill-ui';
-import { DraggableList } from 'AppV2/Components/DraggableList';
-import { TradeTypeList } from 'AppV2/Components/TradeTypeList';
-import { getTradeTypesList, sortCategoriesInTradeTypeOrder } from 'AppV2/Utils/trade-types-utils';
-import { checkContractTypePrefix } from 'AppV2/Utils/contract-type';
 import { Localize, localize } from '@deriv/translations';
 import { safeParse } from '@deriv/utils';
-import TradeTypesSelectionGuide from 'AppV2/Components/OnboardingGuide/TradeTypesSelectionGuide';
+import { ActionSheet, Button, Chip, Text } from '@deriv-com/quill-ui';
+
 import Carousel from 'AppV2/Components/Carousel';
 import CarouselHeader from 'AppV2/Components/Carousel/carousel-header';
-import TradeTypesContent from './trade-types-content';
-import Guide from '../../Components/Guide';
+import TradeTypesSelectionGuide from 'AppV2/Components/OnboardingGuide/TradeTypesSelectionGuide';
+import { checkContractTypePrefix } from 'AppV2/Utils/contract-type';
+import { getTradeTypesList, sortCategoriesInTradeTypeOrder } from 'AppV2/Utils/trade-types-utils';
+import { useTraderStore } from 'Stores/useTraderStores';
+
 import { sendOpenGuideToAnalytics } from '../../../Analytics';
+import Guide from '../../Components/Guide';
+
+import TradeTypesContent from './trade-types-content';
 
 type TTradeTypesProps = {
     onTradeTypeSelect: (
@@ -278,7 +281,9 @@ const TradeTypes = ({ contract_type, onTradeTypeSelect, trade_types, is_dark_mod
                 </Button>
             )}
             <ActionSheet.Root
-                className='trade-types-dialog'
+                className={clsx('trade-types-dialog', {
+                    'trade-types-dialog--is_editing': is_editing,
+                })}
                 isOpen={is_open}
                 expandable={false}
                 onClose={handleCloseTradeTypes}

--- a/packages/trader/src/AppV2/Containers/Trade/trade.scss
+++ b/packages/trader/src/AppV2/Containers/Trade/trade.scss
@@ -73,9 +73,15 @@
 }
 .trade-types-dialog {
     &__title {
-        margin: var(--core-spacing-1200) var(--core-spacing-50);
+        margin: var(--core-spacing-1000) var(--core-spacing-50);
     }
     &__content {
         padding-top: var(--core-spacing-50);
+        &--is_editing {
+            overflow: hidden;
+        }
+    }
+    &--is_editing {
+        overflow: hidden;
     }
 }

--- a/packages/trader/src/AppV2/Containers/Trade/trade.scss
+++ b/packages/trader/src/AppV2/Containers/Trade/trade.scss
@@ -71,15 +71,16 @@
         }
     }
 }
+
+.quill-action-sheet--portal--wrapper:has(.trade-types-dialog--is_editing) {
+    overflow-y: hidden;
+}
 .trade-types-dialog {
     &__title {
-        margin: var(--core-spacing-1000) var(--core-spacing-50);
+        margin: var(--core-spacing-1200) var(--core-spacing-50);
     }
     &__content {
         padding-top: var(--core-spacing-50);
-        &--is_editing {
-            overflow: hidden;
-        }
     }
     &--is_editing {
         overflow: hidden;


### PR DESCRIPTION
## Changes:

**Reasons:**
TrackJS  `{"message":"Invariant failed"}` was caused by `react-beautiful-dnd` library, that is used for trade types drag-and-drop functionality. In all logs users were changing the order of trade types and get an error. In dev mode on localhost it's possible to reproduce it and get '`Droppable: unsupported nested scroll container detected.A Droppable can only have one scroll parent (which can be itself)Nested scroll containers are currently not supported.'`. 
**Solutions:**
There are 3 ways of solving the issue:
1. To find all parents containers with `overflow` css property equal to `scroll/auto` and make them not scrollable. According to the library documentation it's possible to have only 1 scrollable parent, so in my implementation it's `action-sheet--content trade-types-dialog__content`, because we want to leave trade types scrollable on small screens.
2. Replace library with the new one. `react-beautiful-dnd` library will be deprecated in 2025 ([link1](https://github.com/atlassian/react-beautiful-dnd#disable-warnings) and [link2](https://github.com/atlassian/react-beautiful-dnd/issues/2672)), so sooner or earlier we need to migrate to another library.
3. Remove warnings and errors from the library ([link](https://github.com/dudestein/react-beautiful-dnd-pt/blob/master/docs/guides/developer-warnings.md)).  with the command `window['__react-beautiful-dnd-disable-dev-warnings'] = true;` . Not recommended

### Screenshots:

<img width="850" alt="Screenshot 2024-12-19 at 11 04 50 AM" src="https://github.com/user-attachments/assets/97a4a615-0697-406e-8eb0-b1cd354390a5" />
<img width="936" alt="Screenshot 2024-12-19 at 11 05 06 AM" src="https://github.com/user-attachments/assets/26abe221-d680-42bd-9c99-c525cf16ad8d" />

Screenshot of the error on localhost
<img width="1653" alt="Screenshot 2024-12-17 at 11 45 43 AM" src="https://github.com/user-attachments/assets/824d7395-67d6-4896-acee-00df59f8fba2" />
