### PR TITLE
chore: add redirection for staging and production bot to standalone bot

### DIFF
--- a/packages/bot-web-ui/src/app/app-main.tsx
+++ b/packages/bot-web-ui/src/app/app-main.tsx
@@ -12,7 +12,26 @@ type TAppProps = {
     };
 };
 
+const originToDomainMap = {
+    'staging-app.deriv.com': 'staging-dbot.deriv.com',
+    'staging-app.deriv.me': 'staging-dbot.deriv.com',
+    'staging-app.deriv.be': 'staging-dbot.deriv.com',
+    'app.deriv.com': 'dbot.deriv.com',
+    'app.deriv.me': 'dbot.deriv.me',
+    'app.deriv.be': 'dbot.deriv.be',
+};
+
 const App = ({ passthrough }: TAppProps) => {
+    // Extract the correct domain based on the current origin
+    const targetDomain = Object.entries(originToDomainMap).find(([origin]) =>
+        window.location.origin.includes(origin)
+    )?.[1];
+
+    // Redirect to the dbot.deriv.com only from staging and production
+    if (targetDomain) {
+        window.location.assign(`https://${targetDomain}`);
+    }
+
     const { root_store, WS } = passthrough;
     React.useEffect(() => {
         // Setting the inner height of the document to the --vh variable to fix the issue

--- a/packages/bot-web-ui/src/app/app-main.tsx
+++ b/packages/bot-web-ui/src/app/app-main.tsx
@@ -23,9 +23,7 @@ const originToDomainMap = {
 
 const App = ({ passthrough }: TAppProps) => {
     // Extract the correct domain based on the current origin
-    const targetDomain = Object.entries(originToDomainMap).find(([origin]) =>
-        window.location.origin.includes(origin)
-    )?.[1];
+    const targetDomain = originToDomainMap[window.location.host as keyof typeof originToDomainMap];
 
     // Redirect to the dbot.deriv.com only from staging and production
     if (targetDomain) {

--- a/packages/wallets/src/constants/constants.tsx
+++ b/packages/wallets/src/constants/constants.tsx
@@ -26,6 +26,7 @@ export const getOptionsAndMultipliersContent = (
     {
         availability: 'Non-EU',
         description: localize('The ultimate bot trading platform.'),
+        isExternal: true,
         key: 'bot',
         redirect: '/bot',
         title: 'Deriv Bot',


### PR DESCRIPTION
This pull request includes changes to the `packages/bot-web-ui` and `packages/wallets` to enhance redirection functionality and update content constants. The most important changes are listed below:

Redirection functionality:

* [`packages/bot-web-ui/src/app/app-main.tsx`](diffhunk://#diff-894a3e7a00fd927125af65c43ef2e9e28476a990e20e74d7b7fa4d56bf7c0ba4R15-R34): Added a mapping from origin to domain and implemented a redirection mechanism to ensure users are redirected to the appropriate `dbot` domain based on the current origin.

Content constants update:

* [`packages/wallets/src/constants/constants.tsx`](diffhunk://#diff-8fe136de4d9ebe1cb74f2601acd838491842646392046a9d5c64266c0fa60aa5R29): Added the `isExternal` property to the 'Deriv Bot' option to indicate that it is an external link.## Changes:

Please provide a summary of the change.

### Screenshots:

Please provide some screenshots of the change.
