### PR TITLE
[FEQ-2705] george / FEQ-2705 / Avoid Triggering Coveralls Workflow on PR Edits

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master 
   pull_request:
-    types: [opened, synchronize, edited]
+    types: [opened, synchronize]
     
 jobs:
   test:


### PR DESCRIPTION
## Changes:

The Coveralls workflow was being unnecessarily triggered on PR metadata edits (e.g., title or description changes) in the `deriv-app` project. This was caused by the inclusion of the edited event type in the workflow trigger for pull_request.

This PR removes the `edited` event type to ensure the workflow only runs for relevant events like new commits or PR creation, optimizing CI/CD resource usage.
