### PR TITLE
[WALL] george / WALL-5263 / TrackJS undefined is not an object (evaluating 'e.length') 

### DIFF
--- a/packages/translations/src/i18next/i18next.ts
+++ b/packages/translations/src/i18next/i18next.ts
@@ -139,7 +139,7 @@ const initial_language = getInitialLanguage();
 const i18n_config = {
     react: {
         hashTransKey(defaultValue: string) {
-            return crc32(defaultValue);
+            return crc32(defaultValue ?? '');
         },
         useSuspense: false,
     },


### PR DESCRIPTION
## Changes:

- If we are passing `an empty string` or `undefined` into `<Localize/>` component the application crashes. I've added the fallback into `hashTransKey` handler to avoid application crashing. `<Localize />` component is using `<Trans />` component under the hood from `react-i18next` library. And `hashTransKey` is running inside `<Trans />` component, so most likely the issue is inside this third-party library, because `defaults` prop in  `<Trans />` component receives an empty string, but in `hashTransKey` it becomes `undefined`. For now I've made a quick fix for this issue by adding fallback into `hashTransKey` handler.

### Screenshots:
<img width="493" alt="Screenshot 2024-12-26 at 13 48 30" src="https://github.com/user-attachments/assets/69c91b1a-7b67-4dcd-81c0-b486a42c169e" />

https://github.com/user-attachments/assets/e949e27d-460a-41d0-b947-3d9ced7f7223





