### PR TITLE
Akmal / feat: implement trading days API

### DIFF
--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/__tests__/duration_container.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/__tests__/duration_container.spec.tsx
@@ -20,6 +20,7 @@ global.HTMLElement.prototype.scrollIntoView = jest.fn();
 jest.mock('Stores/Modules/Trading/Helpers/contract-type', () => ({
     ContractType: {
         getTradingEvents: jest.fn(),
+        getTradingDays: jest.fn(),
     },
 }));
 

--- a/packages/trader/src/Modules/Trading/Components/Form/DatePicker/__tests__/trading-date-picker.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/DatePicker/__tests__/trading-date-picker.spec.tsx
@@ -25,6 +25,7 @@ jest.mock('Stores/Modules/Trading/Helpers/contract-type', () => ({
                 descrip: "New Year's Day",
             },
         ]),
+        getTradingDays: jest.fn(() => ['Mon', 'Tue', 'Wed', 'Thu', 'Fri']),
     },
 }));
 describe('<TradingTimePicker />', () => {

--- a/packages/trader/src/Modules/Trading/Components/Form/DatePicker/trading-date-picker.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/DatePicker/trading-date-picker.tsx
@@ -134,9 +134,9 @@ const TradingDatePicker = observer(({ id, is_24_hours_contract, mode, name }: TT
 
             if (trading_days) {
                 const all_days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
-                new_disabled_days = all_days
-                    .map((day: (typeof all_days)[number], index) => (!trading_days.includes(day) ? index : -1))
-                    .filter(index => index !== -1);
+                new_disabled_days = all_days.reduce<number[]>((disabled, day, index) => {
+                    return trading_days.includes(day) ? disabled : [...disabled, index];
+                }, []);
             }
 
             events?.forEach(evt => {

--- a/packages/trader/src/Modules/Trading/Components/Form/DatePicker/trading-date-picker.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/DatePicker/trading-date-picker.tsx
@@ -63,7 +63,7 @@ const TradingDatePicker = observer(({ id, is_24_hours_contract, mode, name }: TT
     const getMomentContractStartDateTime = () => {
         return setTime(
             toMoment(getMinDuration()),
-            isTimeValid(start_time ?? '') ? start_time : server_time?.format('HH:mm:ss') ?? ''
+            isTimeValid(start_time ?? '') ? start_time : (server_time?.format('HH:mm:ss') ?? '')
         );
     };
 
@@ -126,13 +126,21 @@ const TradingDatePicker = observer(({ id, is_24_hours_contract, mode, name }: TT
         async (e = toMoment().format('YYYY-MM-DD')) => {
             const new_market_events: TMarketEvent[] = [];
             let new_disabled_days: number[] = [];
-            const events = await ContractType.getTradingEvents(e, symbol);
+
+            const [events, trading_days] = await Promise.all([
+                ContractType.getTradingEvents(e, symbol),
+                ContractType.getTradingDays(e, symbol),
+            ]);
+
+            if (trading_days) {
+                const all_days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+                new_disabled_days = all_days
+                    .map((day: (typeof all_days)[number], index) => (!trading_days.includes(day) ? index : -1))
+                    .filter(index => index !== -1);
+            }
+
             events?.forEach(evt => {
                 const dates = evt.dates.split(', '); // convert dates str into array
-                const idx = dates.indexOf('Fridays');
-                if (idx !== -1) {
-                    new_disabled_days = [6, 0]; // Sat, Sun
-                }
                 new_market_events.push({
                     dates,
                     descrip: evt.descrip,

--- a/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.ts
+++ b/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.ts
@@ -452,6 +452,40 @@ export const ContractType = (() => {
         return trading_events[date][underlying as string];
     };
 
+    const getTradingDays = async (date: string, underlying: string | null = null) => {
+        if (!date || !underlying) {
+            return null;
+        }
+
+        const trading_times_response: TradingTimesResponse = await WS.tradingTimes(date);
+        const trading_times_data = trading_times_response.trading_times as TradingTimes;
+
+        type SymbolType = NonNullable<
+            NonNullable<(typeof trading_times_data.markets)[number]['submarkets']>[number]['symbols']
+        >[number];
+
+        if (getPropertyValue(trading_times_response, ['trading_times', 'markets'])) {
+            const symbol_data = trading_times_data.markets.reduce((acc: SymbolType[], market) => {
+                if (!market.submarkets) return acc;
+
+                const submarket_symbols = market.submarkets.reduce((sub_acc: SymbolType[], submarket) => {
+                    if (!submarket.symbols) return sub_acc;
+
+                    const found_symbol = submarket.symbols.find(s => s.symbol === underlying);
+                    return found_symbol ? [...sub_acc, found_symbol] : sub_acc;
+                }, []);
+
+                return [...acc, ...submarket_symbols];
+            }, [])[0];
+
+            if (symbol_data) {
+                return symbol_data.trading_days;
+            }
+        }
+
+        return null;
+    };
+
     const getTradingTimes = async (
         date: string | null,
         underlying: string | null = null
@@ -719,6 +753,7 @@ export const ContractType = (() => {
         getStartTime,
         getStartType,
         getTradingEvents,
+        getTradingDays,
         getTradingTimes,
         getContractCategories: () => ({
             contract_types_list: available_categories,


### PR DESCRIPTION
## Changes:

This feature utilizes the `trading_days` property from the Trading Times API to deliver detailed trading availability.

1. Property Integration: Leverage the `trading_days` property to retrieve specific market open days.
2. Accurate Data: Provide users with precise information on trading availability for better planning.
3. Enhanced Functionality: Improve API usage by incorporating the `trading_days` property into trading tools.

This feature enhances the system by integrating detailed trading day information from the Trading Times API.

