### PR TITLE
Nijil / Info content is missing in Carousal component for RTL layout

### DIFF
--- a/packages/components/src/components/icon/icons.js
+++ b/packages/components/src/components/icon/icons.js
@@ -640,6 +640,7 @@ import './common/ic-tour-guide-step2.svg';
 import './common/ic-trade.svg';
 import './common/ic-trading-view-chart.svg';
 import './common/ic-transactions.svg';
+import './common/ic-triangle-exclamation-xl.svg';
 import './common/ic-tutorials-tabs.svg';
 import './common/ic-unarchive.svg';
 import './common/ic-undo.svg';

--- a/packages/trader/src/AppV2/Components/Carousel/carousel.tsx
+++ b/packages/trader/src/AppV2/Components/Carousel/carousel.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import CarouselHeader, { TQuillIcon } from './carousel-header';
 import { useSwipeable } from 'react-swipeable';
 import clsx from 'clsx';
+import { getLanguage } from '@deriv/translations';
+import CarouselHeader, { TQuillIcon } from './carousel-header';
 
 type TCarousel = {
     classname?: string;
@@ -38,6 +39,8 @@ const Carousel = ({
 
     const isControlled = current_index !== undefined && setCurrentIndex !== undefined;
     const index = isControlled ? current_index : internalIndex;
+    const lang = getLanguage();
+    const is_rtl = lang === 'AR';
 
     const handleNextClick = () => {
         if (!is_infinite_loop && index + 1 >= pages.length) return;
@@ -76,7 +79,11 @@ const Carousel = ({
                 {...(is_swipeable ? swipe_handlers : {})}
             >
                 {pages.map(({ component, id }) => (
-                    <li className='carousel__item' style={{ transform: `translateX(-${index * 100}%)` }} key={id}>
+                    <li
+                        className='carousel__item'
+                        style={{ transform: is_rtl ? `translateX(${index * 100}%)` : `translateX(-${index * 100}%)` }}
+                        key={id}
+                    >
                         {component}
                     </li>
                 ))}

--- a/packages/trader/src/AppV2/Components/Carousel/carousel.tsx
+++ b/packages/trader/src/AppV2/Components/Carousel/carousel.tsx
@@ -81,7 +81,7 @@ const Carousel = ({
                 {pages.map(({ component, id }) => (
                     <li
                         className='carousel__item'
-                        style={{ transform: is_rtl ? `translateX(${index * 100}%)` : `translateX(-${index * 100}%)` }}
+                        style={{ transform: `translateX(${index * 100 * (is_rtl ? 1 : -1)}%)` }}
                         key={id}
                     >
                         {component}


### PR DESCRIPTION
## Changes:

Info content is missing in Carousal component for RTL layout

### Screenshots:

Before
<img width="401" alt="Screenshot 2025-01-02 at 7 06 54 PM" src="https://github.com/user-attachments/assets/262dc555-2eb4-4624-90df-645164d84f88" />

After
<img width="381" alt="Screenshot 2025-01-02 at 7 07 14 PM" src="https://github.com/user-attachments/assets/91813979-40d7-48eb-9d99-e9faf9e1b68a" />
