### PR TITLE
[WALL] george / WALL-5275 / Remove DerivedFX from compare account tables

### DIFF
--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.tsx
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.tsx
@@ -1,22 +1,25 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import classNames from 'classnames';
-import { Text, Icon, PageOverlay, CFDCompareAccountsCarousel } from '@deriv/components';
-import { routes } from '@deriv/shared';
-import { Localize, localize } from '@deriv/translations';
-import { observer, useStore } from '@deriv/stores';
-import { useDevice } from '@deriv-com/ui';
+
+import { CFDCompareAccountsCarousel, Icon, PageOverlay, Text } from '@deriv/components';
 import { useIsRtl } from '@deriv/hooks';
-import CFDCompareAccountsCard from './cfd-compare-accounts-card';
+import { routes } from '@deriv/shared';
+import { observer, useStore } from '@deriv/stores';
+import { Localize, localize } from '@deriv/translations';
+import { useDevice } from '@deriv-com/ui';
+
 import {
-    getSortedCFDAvailableAccounts,
+    ctrader_data,
+    dxtrade_data,
+    getCtraderDemoData,
+    getDxtradeDemoData,
     getEUAvailableAccounts,
     getMT5DemoData,
-    getDxtradeDemoData,
-    getCtraderDemoData,
-    dxtrade_data,
-    ctrader_data,
+    getSortedCFDAvailableAccounts,
 } from '../../Helpers/compare-accounts-config';
+
+import CFDCompareAccountsCard from './cfd-compare-accounts-card';
 
 const CompareCFDs = observer(() => {
     const { isDesktop } = useDevice();
@@ -147,7 +150,7 @@ const CompareCFDs = observer(() => {
                     {all_cfd_available_accounts.map(item => (
                         <CFDCompareAccountsCard
                             trading_platforms={item}
-                            key={item.market_type + item.shortcode}
+                            key={item.market_type + item.shortcode + (item?.product || '')}
                             is_eu_user={is_eu_user}
                             is_demo={is_demo}
                         />

--- a/packages/cfd/src/Helpers/compare-accounts-config.ts
+++ b/packages/cfd/src/Helpers/compare-accounts-config.ts
@@ -1,6 +1,8 @@
 import { localize } from '@deriv/translations';
+
 import { TInstrumentsIcon, TModifiedTradingPlatformAvailableAccount, TProducts } from '../Components/props.types';
-import { CFD_PLATFORMS, MARKET_TYPE, JURISDICTION, REGION, MARKET_TYPE_SHORTCODE, PRODUCT } from './cfd-config';
+
+import { CFD_PLATFORMS, JURISDICTION, MARKET_TYPE, MARKET_TYPE_SHORTCODE, PRODUCT, REGION } from './cfd-config';
 
 // Map the accounts according to the market type
 const getHighlightedIconLabel = (
@@ -40,8 +42,6 @@ const getHighlightedIconLabel = (
                 return 'forex';
             } else if (item === 'ETFs') {
                 return 'ETFs'; // Preserve the original form for ETFs
-            } else if (item === 'Derived FX') {
-                return 'derived_FX'; // Handle FX case
             }
             return item.toLowerCase().replace(/\s+/g, '_'); // Replace spaces with underscores
         });
@@ -67,12 +67,6 @@ const getHighlightedIconLabel = (
             id: 'basket_indices',
             icon: 'Baskets',
             text: localize('Basket indices'),
-            is_available: selected_region === REGION.NON_EU,
-        },
-        {
-            id: 'derived_FX',
-            icon: 'DerivedFX',
-            text: localize('Derived FX'),
             is_available: selected_region === REGION.NON_EU,
         },
     ];

--- a/packages/wallets/src/features/cfd/screens/CompareAccounts/compareAccountsConfig.ts
+++ b/packages/wallets/src/features/cfd/screens/CompareAccounts/compareAccountsConfig.ts
@@ -66,11 +66,6 @@ const getHighlightedIconLabel = (values: TValues) => {
                   { highlighted: shouldHighlight('Basket indices'), icon: 'Baskets', text: localize('Basket indices') },
               ] as const)
             : []),
-        ...(!isEuRegion
-            ? ([
-                  { highlighted: shouldHighlight('Derived FX'), icon: 'DerivedFX', text: localize('Derived FX') },
-              ] as const)
-            : []),
     ] as const;
 };
 


### PR DESCRIPTION
## Changes:

- remove DerivedFX from compare account tables from wallets and legacy
- fix duplicated key error in mobile/tablet view

### Screenshots:

![Screenshot 2025-01-08 at 16 48 48](https://github.com/user-attachments/assets/42ab1919-edc4-45a5-bd9c-5cabe05abbfe)
![Screenshot 2025-01-08 at 16 58 48](https://github.com/user-attachments/assets/3abb6dcd-ed19-4117-8715-d2d2f560e7a4)

