### PR TITLE
fix: timer picker field should display appropriate value for future dates

### DIFF
--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
@@ -128,7 +128,6 @@ const DayInput = ({
                     hasCloseButton: true,
                     style: { marginBottom: '48px' },
                 });
-                setIsDisabled(true);
             } else {
                 setIsDisabled(false);
             }
@@ -253,7 +252,7 @@ const DayInput = ({
                 readOnly
                 textAlignment='center'
                 name='time'
-                value={`${(is_24_hours_contract ? end_time : expiry_time_input) || '23:59:59'} GMT`}
+                value={`${(is_24_hours_contract ? end_time : isSameDate && expiry_time_input) || '23:59:59'} GMT`}
                 disabled={!is_24_hours_contract}
                 onClick={() => {
                     setOpenTimePicker(true);

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
@@ -128,7 +128,7 @@ const DayInput = ({
                     hasCloseButton: true,
                     style: { marginBottom: '48px' },
                 });
-                setIsDisabled(false);
+                setIsDisabled(true);
             } else {
                 setIsDisabled(false);
             }

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
@@ -128,6 +128,7 @@ const DayInput = ({
                     hasCloseButton: true,
                     style: { marginBottom: '48px' },
                 });
+                setIsDisabled(false);
             } else {
                 setIsDisabled(false);
             }


### PR DESCRIPTION
## Changes:

Fixed the below issue. the time should be 23:59 for future [dates](url)
<img width="411" alt="Screenshot 2025-02-06 at 2 42 26 PM" src="https://github.com/user-attachments/assets/74a2d331-d2ac-48fd-b44e-01b8cfe011c0" />

### Screenshots:

Please provide some screenshots of the change.
