### PR TITLE
[TRAH] shontzu/TRAH-5356/fe-implementation-api-group-cleanup

### DIFF
--- a/packages/appstore/src/components/cfds-listing-logged-out/cfds-listing-logged-out.tsx
+++ b/packages/appstore/src/components/cfds-listing-logged-out/cfds-listing-logged-out.tsx
@@ -1,17 +1,20 @@
 import React from 'react';
-import { observer, useStore } from '@deriv/stores';
+
 import { Text } from '@deriv/components';
-import { redirectToLogin } from '@deriv/shared';
+import { redirectToLogin, CFD_PLATFORMS } from '@deriv/shared';
+import { observer, useStore } from '@deriv/stores';
 import { getLanguage, localize } from '@deriv/translations';
-import { getHasDivider } from 'Constants/utils';
+
 import ListingContainer from 'Components/containers/listing-container';
 import TradingAppCard from 'Components/containers/trading-app-card';
 import CFDsDescription from 'Components/elements/cfds-description';
 import CFDsTitle from 'Components/elements/cfds-title';
+import { getHasDivider } from 'Constants/utils';
+
 import './cfds-listing-logged-out.scss';
 
 const CFDsListingLoggedOut = observer(() => {
-    const { traders_hub } = useStore();
+    const { traders_hub, client } = useStore();
     const {
         available_dxtrade_accounts,
         available_ctrader_accounts,
@@ -19,6 +22,7 @@ const CFDsListingLoggedOut = observer(() => {
         selected_region,
         is_eu_user,
     } = traders_hub;
+    const { is_eu } = client;
 
     return (
         <ListingContainer title={<CFDsTitle />} description={<CFDsDescription />}>
@@ -28,15 +32,20 @@ const CFDsListingLoggedOut = observer(() => {
                 </Text>
             </div>
             {combined_cfd_mt5_accounts.map((existing_account, index: number) => {
+                // This is for backward compatibility
+                // before BE change, EU market_type is financial. With BE change, EU market_type becomes synthetic
+                const is_eu_standard = is_eu && existing_account.market_type !== 'financial';
+
                 const list_size = combined_cfd_mt5_accounts.length;
+
                 return (
                     <TradingAppCard
                         action_type={existing_account.action_type}
                         availability={selected_region}
                         clickable_icon
-                        icon={existing_account.icon}
+                        icon={is_eu_standard ? 'Derived' : existing_account.icon}
                         sub_title={existing_account?.sub_title}
-                        name={existing_account?.name ?? ''}
+                        name={is_eu_standard ? 'Standard' : existing_account.name}
                         short_code_and_region={existing_account?.short_code_and_region}
                         platform={existing_account.platform}
                         description={existing_account.description}

--- a/packages/cfd/src/Containers/cfd-compare-accounts/__tests__/cfd-compare-accounts-title-icon.spec.tsx
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/__tests__/cfd-compare-accounts-title-icon.spec.tsx
@@ -82,13 +82,13 @@ describe('<CFDCompareAccountsTitleIcon />', () => {
     test('should render correct title for EU Clients', () => {
         mocked_props.trading_platforms = {
             platform: 'mt5',
-            market_type: 'financial',
+            market_type: 'gaming',
             shortcode: 'maltainvest',
             product: 'financial',
         };
         mocked_props.is_eu_user = true;
         render(<CFDCompareAccountsTitleIcon {...mocked_props} />);
-        expect(screen.getByText('CFDs')).toBeInTheDocument();
+        expect(screen.getByText('Standard')).toBeInTheDocument();
     });
 
     test('should render correct title for standard product type in demo account', () => {
@@ -159,11 +159,11 @@ describe('<CFDCompareAccountsTitleIcon />', () => {
 
     test('should render correct title for EU clients demo accounts', () => {
         mocked_props.trading_platforms.platform = 'mt5';
-        mocked_props.trading_platforms.market_type = 'financial';
+        mocked_props.trading_platforms.market_type = 'gaming';
         mocked_props.trading_platforms.shortcode = 'svg';
         mocked_props.is_demo = true;
         mocked_props.is_eu_user = true;
         render(<CFDCompareAccountsTitleIcon {...mocked_props} />);
-        expect(screen.getByText('CFDs demo')).toBeInTheDocument();
+        expect(screen.getByText('Standard demo')).toBeInTheDocument();
     });
 });

--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts-title-icon.tsx
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts-title-icon.tsx
@@ -17,7 +17,10 @@ import {
 
 const CFDCompareAccountsTitleIcon = ({ trading_platforms, is_eu_user, is_demo }: TCompareAccountsCard) => {
     const { isDesktop } = useDevice();
-    const market_type = !is_eu_user ? getMarketType(trading_platforms) : 'CFDs';
+    const market_type =
+        is_eu_user && trading_platforms.market_type === 'financial'
+            ? 'CFDs' // this is for backwards compatibility with BE
+            : getMarketType(trading_platforms);
 
     const market_type_shortcode = generateMarketTypeShortcode(trading_platforms, market_type);
 

--- a/packages/cfd/src/Helpers/compare-accounts-config.ts
+++ b/packages/cfd/src/Helpers/compare-accounts-config.ts
@@ -10,6 +10,7 @@ const getHighlightedIconLabel = (
     selected_region?: string
 ): TInstrumentsIcon[] => {
     const market_type = getMarketType(trading_platforms);
+
     const market_type_shortcode =
         trading_platforms.product === PRODUCT.GOLD
             ? market_type.concat('_', trading_platforms.product)
@@ -129,6 +130,7 @@ const platformsHeaderLabel = {
 const getAccountIcon = (shortcode: string, product?: TProducts) => {
     switch (shortcode) {
         case MARKET_TYPE.SYNTHETIC:
+        case MARKET_TYPE.GAMING:
             return 'Standard';
         case MARKET_TYPE.FINANCIAL:
             switch (product) {
@@ -276,7 +278,6 @@ const getEUAvailableAccounts = (available_accounts: TModifiedTradingPlatformAvai
     const financial_accounts = available_accounts
         .filter(
             item =>
-                item.market_type === MARKET_TYPE.FINANCIAL &&
                 item.shortcode === JURISDICTION.MALTA_INVEST &&
                 item.is_default_jurisdiction === 'true' &&
                 item.product !== PRODUCT.GOLD
@@ -355,9 +356,7 @@ const getMT5DemoData = (available_accounts: TModifiedTradingPlatformAvailableAcc
         item =>
             item.market_type === MARKET_TYPE.FINANCIAL && item.product !== PRODUCT.STP && item.product !== PRODUCT.GOLD
     );
-    const gaming_demo_accounts = available_accounts.filter(
-        item => item.market_type === MARKET_TYPE.GAMING && item.shortcode === JURISDICTION.SVG
-    );
+    const gaming_demo_accounts = available_accounts.filter(item => item.market_type === MARKET_TYPE.GAMING);
 
     const gold_demo_accounts = available_accounts.filter(
         item => item.market_type === MARKET_TYPE.FINANCIAL && item.product === PRODUCT.GOLD

--- a/packages/core/src/Stores/traders-hub-store.js
+++ b/packages/core/src/Stores/traders-hub-store.js
@@ -410,17 +410,6 @@ export default class TradersHubStore extends BaseStore {
             is_logged_in,
             is_trading_platform_available_account_loaded,
         } = this.root_store.client;
-        const getAccountDesc = () => {
-            return !this.is_eu_user || this.is_demo_low_risk
-                ? localize('CFDs on financial instruments.')
-                : localize('CFDs on derived and financial instruments.');
-        };
-        const getSwapFreeAccountDesc = () => {
-            return localize('Swap-free CFDs on selected financial and derived instruments.');
-        };
-        const getZeroSpreadAccountDesc = () => {
-            return localize('Zero spread CFDs on financial and derived instruments');
-        };
 
         const getMT5Accounts = [
             {
@@ -433,13 +422,22 @@ export default class TradersHubStore extends BaseStore {
                 availability: 'Non-EU',
             },
             {
-                name: !this.is_eu_user || this.is_demo_low_risk ? 'Financial' : 'CFDs',
-                description: getAccountDesc(),
+                name: 'Financial',
+                description: localize('CFDs on financial instruments.'),
                 platform: CFD_PLATFORMS.MT5,
                 market_type: 'financial',
                 product: 'financial',
-                icon: !this.is_eu_user || this.is_demo_low_risk ? 'Financial' : 'CFDs',
-                availability: 'All',
+                icon: 'Financial',
+                availability: 'Non-EU',
+            },
+            {
+                name: 'Standard',
+                description: localize('CFDs on derived and financial instruments.'),
+                platform: CFD_PLATFORMS.MT5,
+                market_type: 'synthetic',
+                product: 'financial',
+                icon: 'Standard',
+                availability: 'EU',
             },
             ...(this.is_real
                 ? [
@@ -456,7 +454,7 @@ export default class TradersHubStore extends BaseStore {
                 : []),
             {
                 name: 'Swap-Free',
-                description: getSwapFreeAccountDesc(),
+                description: localize('Swap-free CFDs on selected financial and derived instruments.'),
                 platform: CFD_PLATFORMS.MT5,
                 market_type: 'all',
                 product: 'swap_free',
@@ -465,7 +463,7 @@ export default class TradersHubStore extends BaseStore {
             },
             {
                 name: localize('Zero Spread'),
-                description: getZeroSpreadAccountDesc(),
+                description: localize('Zero spread CFDs on financial and derived instruments'),
                 platform: CFD_PLATFORMS.MT5,
                 market_type: 'all',
                 product: 'zero_spread',

--- a/packages/core/src/Stores/traders-hub-store.js
+++ b/packages/core/src/Stores/traders-hub-store.js
@@ -410,6 +410,27 @@ export default class TradersHubStore extends BaseStore {
             is_logged_in,
             is_trading_platform_available_account_loaded,
         } = this.root_store.client;
+        const getAccountDesc = () => {
+            return !this.is_eu_user || this.is_demo_low_risk
+                ? localize('CFDs on financial instruments.')
+                : localize('CFDs on derived and financial instruments.');
+        };
+        const getSwapFreeAccountDesc = () => {
+            return localize('Swap-free CFDs on selected financial and derived instruments.');
+        };
+        const getZeroSpreadAccountDesc = () => {
+            return localize('Zero spread CFDs on financial and derived instruments');
+        };
+
+        const getFinancialName = () => {
+            if (!this.is_eu_user || this.is_demo_low_risk) {
+                return 'Financial';
+            }
+            if (is_logged_in) {
+                return 'CFDs';
+            }
+            return 'Standard';
+        };
 
         const getMT5Accounts = [
             {
@@ -422,22 +443,13 @@ export default class TradersHubStore extends BaseStore {
                 availability: 'Non-EU',
             },
             {
-                name: 'Financial',
-                description: localize('CFDs on financial instruments.'),
+                name: getFinancialName(),
+                description: getAccountDesc(),
                 platform: CFD_PLATFORMS.MT5,
                 market_type: 'financial',
                 product: 'financial',
-                icon: 'Financial',
-                availability: 'Non-EU',
-            },
-            {
-                name: 'Standard',
-                description: localize('CFDs on derived and financial instruments.'),
-                platform: CFD_PLATFORMS.MT5,
-                market_type: 'synthetic',
-                product: 'financial',
-                icon: 'Standard',
-                availability: 'EU',
+                icon: getFinancialName(),
+                availability: 'All',
             },
             ...(this.is_real
                 ? [
@@ -454,7 +466,7 @@ export default class TradersHubStore extends BaseStore {
                 : []),
             {
                 name: 'Swap-Free',
-                description: localize('Swap-free CFDs on selected financial and derived instruments.'),
+                description: getSwapFreeAccountDesc(),
                 platform: CFD_PLATFORMS.MT5,
                 market_type: 'all',
                 product: 'swap_free',
@@ -463,7 +475,7 @@ export default class TradersHubStore extends BaseStore {
             },
             {
                 name: localize('Zero Spread'),
-                description: localize('Zero spread CFDs on financial and derived instruments'),
+                description: getZeroSpreadAccountDesc(),
                 platform: CFD_PLATFORMS.MT5,
                 market_type: 'all',
                 product: 'zero_spread',
@@ -855,6 +867,7 @@ export default class TradersHubStore extends BaseStore {
             } else {
                 this.combined_cfd_mt5_accounts = [
                     ...this.combined_cfd_mt5_accounts,
+
                     {
                         icon: account.icon,
                         name: account.name,

--- a/packages/wallets/src/features/cfd/constants.tsx
+++ b/packages/wallets/src/features/cfd/constants.tsx
@@ -96,7 +96,7 @@ export const getMarketTypeDetails = (
             title: getMarketTypeDetailsTitle(product, isEuRegion),
         },
         synthetic: {
-            availability: 'Non-EU',
+            availability: 'All',
             description: localize('CFDs on derived and financial instruments'),
             icon: <AccountsDmt5StandardIcon height={48} width={48} />,
             title: 'Standard',


### PR DESCRIPTION
## Changes:

EU no longer limited to financial products since trading team insisted DIEL financial should have synthetic instrument too

**Before:**
 in EU, MT5 is shown as MT5 `CFDs` with yellow variant icon

**After:**
in EU, MT5 `CFDs`should just show MT5 `Standard` with the regular blue icon

**Note to dev:**
BE deployed in qa137 
use `es` `mf` account for EU tradershub
use `cz` `mfw` for EU wallets


### Screenshots:

#### Tradershub fix:

https://github.com/user-attachments/assets/81cb4c73-fc82-41f1-a8c7-bd1fe904fb39


#### Wallets fix:

https://github.com/user-attachments/assets/708391aa-2b81-4c04-9fc8-35c464e75b6b



