### PR TITLE
Shontzu/TRAH/Unexpected Behaviour on Transfer funds modal after cfd account creation

### DIFF
--- a/packages/cfd/src/Stores/Modules/CFD/cfd-store.js
+++ b/packages/cfd/src/Stores/Modules/CFD/cfd-store.js
@@ -293,6 +293,10 @@ export default class CFDStore extends BaseStore {
                     trading_platform_available_accounts_list_response
                 );
                 this.setCFDSuccessDialog(true);
+                window.sessionStorage.setItem(
+                    'cfd_transfer_to_login_id',
+                    response.trading_platform_new_account.account_id
+                );
                 this.setIsAccountBeingCreated(false);
                 WS.tradingPlatformAccountsList(CFD_PLATFORMS.CTRADER);
                 setPerformanceValue('create_ctrader_account_time');
@@ -591,6 +595,7 @@ export default class CFDStore extends BaseStore {
                 actions?.setSubmitting(false);
                 this.setError(false);
                 this.setIsMt5PasswordChangedModalVisible(false);
+                window.sessionStorage.setItem('cfd_transfer_to_login_id', response.mt5_new_account.login);
                 this.setCFDSuccessDialog(true);
                 await this.getAccountStatus(CFD_PLATFORMS.MT5);
 
@@ -650,6 +655,7 @@ export default class CFDStore extends BaseStore {
         actions.setSubmitting(false);
         this.setError(false);
         this.setCFDSuccessDialog(true);
+        window.sessionStorage.setItem('cfd_transfer_to_login_id', response.trading_platform_new_account.account_id);
         await this.getAccountStatus(CFD_PLATFORMS.DXTRADE);
 
         const trading_platform_accounts_list_response = await WS.tradingPlatformAccountsList(values.platform);


### PR DESCRIPTION
## Changes:

set `transfer_to` after real cfd account creation 
[card](https://app.clickup.com/t/86c26qa09)

### Screenshots:

https://github.com/user-attachments/assets/598a4394-45f1-45d4-a682-61d47b5c9205

This is applicable to mt5, ctrader, and dxtrade

<img width="451" alt="image" src="https://github.com/user-attachments/assets/9809a0b1-7cca-4617-b0ca-45f6e5be9545" />


