### PR TITLE
Niloofar / Add Feature Flag for Redirecting to Low-Code or High-Code Real Account Creation

### DIFF
--- a/packages/core/src/Stores/Helpers/redirectToOutSystems.ts
+++ b/packages/core/src/Stores/Helpers/redirectToOutSystems.ts
@@ -29,7 +29,7 @@ export const OUT_SYSTEMS_TRADERSHUB = Object.freeze({
     STAGING: `https://staging-hub.${domainUrl}/tradershub`,
 });
 
-export const redirectToOutSystems = (landingCompany?: string, currency = '') => {
+export const redirectToOutSystems = (landingCompany?: string) => {
     // redirect to OS Tradershub if feature is enabled
     const isOutSystemsRealAccountCreationEnabled = Analytics?.getFeatureValue(
         'trigger_os_real_account_creation',
@@ -48,7 +48,6 @@ export const redirectToOutSystems = (landingCompany?: string, currency = '') => 
         Cookies.set('os_auth_tokens', JSON.stringify(accountsWithTokens), { domain: URLConstants.baseDomain, expires });
         const params = new URLSearchParams({
             action: 'real-account-signup',
-            ...(currency ? { currency } : {}),
             target: landingCompany || LANDING_COMPANIES.MALTAINVEST,
         });
         const baseUrl = isProduction() ? OUT_SYSTEMS_TRADERSHUB.PRODUCTION : OUT_SYSTEMS_TRADERSHUB.STAGING;

--- a/packages/core/src/Stores/Helpers/redirectToOutSystems.ts
+++ b/packages/core/src/Stores/Helpers/redirectToOutSystems.ts
@@ -7,10 +7,8 @@ import { URLConstants } from '@deriv-com/utils';
 const isBrowser = () => typeof window !== 'undefined';
 
 const derivComUrl = 'deriv.com';
-const derivMeUrl = 'deriv.me';
-const derivBeUrl = 'deriv.be';
 
-const supportedDomains = [derivComUrl, derivMeUrl, derivBeUrl];
+const supportedDomains = [derivComUrl];
 const domainUrlInitial = (isBrowser() && window.location.hostname.split('app.')[1]) || '';
 const domainUrl = supportedDomains.includes(domainUrlInitial) ? domainUrlInitial : derivComUrl;
 

--- a/packages/core/src/Stores/Helpers/redirectToOutSystems.ts
+++ b/packages/core/src/Stores/Helpers/redirectToOutSystems.ts
@@ -1,7 +1,6 @@
 import Cookies from 'js-cookie';
 
 import { getAccountsFromLocalStorage } from '@deriv/utils';
-import { Analytics } from '@deriv-com/analytics';
 import { URLConstants } from '@deriv-com/utils';
 
 const isBrowser = () => typeof window !== 'undefined';
@@ -10,7 +9,7 @@ const derivComUrl = 'deriv.com';
 
 const supportedDomains = [derivComUrl];
 const domainUrlInitial = (isBrowser() && window.location.hostname.split('app.')[1]) || '';
-const domainUrl = supportedDomains.includes(domainUrlInitial) ? domainUrlInitial : derivComUrl;
+export const isOutsystemsSupported = supportedDomains.includes(domainUrlInitial);
 
 export const LANDING_COMPANIES = Object.freeze({
     BVI: 'bvi',
@@ -25,34 +24,26 @@ export const isProduction = () => {
 };
 
 export const OUT_SYSTEMS_TRADERSHUB = Object.freeze({
-    PRODUCTION: `https://hub.${domainUrl}/tradershub`,
-    STAGING: `https://staging-hub.${domainUrl}/tradershub`,
+    PRODUCTION: `https://hub.deriv.com/tradershub`,
+    STAGING: `https://staging-hub.deriv.com/tradershub`,
 });
 
 export const redirectToOutSystems = (landingCompany?: string) => {
-    // redirect to OS Tradershub if feature is enabled
-    const isOutSystemsRealAccountCreationEnabled = Analytics?.getFeatureValue(
-        'trigger_os_real_account_creation',
-        false
-    );
-
-    if (isOutSystemsRealAccountCreationEnabled) {
-        const clientAccounts = getAccountsFromLocalStorage() ?? {};
-        if (!Object.keys(clientAccounts).length) return;
-        const accountsWithTokens: Record<string, unknown> = {};
-        Object.keys(clientAccounts).forEach(loginid => {
-            const account = clientAccounts[loginid];
-            accountsWithTokens[loginid] = { token: account.token };
-        });
-        const expires = new Date(new Date().getTime() + 1 * 60 * 1000); // 1 minute
-        Cookies.set('os_auth_tokens', JSON.stringify(accountsWithTokens), { domain: URLConstants.baseDomain, expires });
-        const params = new URLSearchParams({
-            action: 'real-account-signup',
-            target: landingCompany || LANDING_COMPANIES.MALTAINVEST,
-        });
-        const baseUrl = isProduction() ? OUT_SYSTEMS_TRADERSHUB.PRODUCTION : OUT_SYSTEMS_TRADERSHUB.STAGING;
-        const redirectURL = new URL(`${baseUrl}/redirect`);
-        redirectURL.search = params.toString();
-        return (window.location.href = redirectURL.toString());
-    }
+    const clientAccounts = getAccountsFromLocalStorage() ?? {};
+    if (!Object.keys(clientAccounts).length) return;
+    const accountsWithTokens: Record<string, unknown> = {};
+    Object.keys(clientAccounts).forEach(loginid => {
+        const account = clientAccounts[loginid];
+        accountsWithTokens[loginid] = { token: account.token };
+    });
+    const expires = new Date(new Date().getTime() + 1 * 60 * 1000); // 1 minute
+    Cookies.set('os_auth_tokens', JSON.stringify(accountsWithTokens), { domain: URLConstants.baseDomain, expires });
+    const params = new URLSearchParams({
+        action: 'real-account-signup',
+        target: landingCompany || LANDING_COMPANIES.MALTAINVEST,
+    });
+    const baseUrl = isProduction() ? OUT_SYSTEMS_TRADERSHUB.PRODUCTION : OUT_SYSTEMS_TRADERSHUB.STAGING;
+    const redirectURL = new URL(`${baseUrl}/redirect`);
+    redirectURL.search = params.toString();
+    return (window.location.href = redirectURL.toString());
 };

--- a/packages/core/src/Stores/Helpers/redirectToOutSystems.ts
+++ b/packages/core/src/Stores/Helpers/redirectToOutSystems.ts
@@ -1,0 +1,61 @@
+import Cookies from 'js-cookie';
+
+import { getAccountsFromLocalStorage } from '@deriv/utils';
+import { Analytics } from '@deriv-com/analytics';
+import { URLConstants } from '@deriv-com/utils';
+
+const isBrowser = () => typeof window !== 'undefined';
+
+const derivComUrl = 'deriv.com';
+const derivMeUrl = 'deriv.me';
+const derivBeUrl = 'deriv.be';
+
+const supportedDomains = [derivComUrl, derivMeUrl, derivBeUrl];
+const domainUrlInitial = (isBrowser() && window.location.hostname.split('app.')[1]) || '';
+const domainUrl = supportedDomains.includes(domainUrlInitial) ? domainUrlInitial : derivComUrl;
+
+export const LANDING_COMPANIES = Object.freeze({
+    BVI: 'bvi',
+    LABUAN: 'labuan',
+    MALTAINVEST: 'maltainvest',
+    SVG: 'svg',
+    VANUATU: 'vanuatu',
+});
+
+export const isProduction = () => {
+    return process.env.NODE_ENV === 'production';
+};
+
+export const OUT_SYSTEMS_TRADERSHUB = Object.freeze({
+    PRODUCTION: `https://hub.${domainUrl}/tradershub`,
+    STAGING: `https://staging-hub.${domainUrl}/tradershub`,
+});
+
+export const redirectToOutSystems = (landingCompany?: string, currency = '') => {
+    // redirect to OS Tradershub if feature is enabled
+    const isOutSystemsRealAccountCreationEnabled = Analytics?.getFeatureValue(
+        'trigger_os_real_account_creation',
+        false
+    );
+
+    if (isOutSystemsRealAccountCreationEnabled) {
+        const clientAccounts = getAccountsFromLocalStorage() ?? {};
+        if (!Object.keys(clientAccounts).length) return;
+        const accountsWithTokens: Record<string, unknown> = {};
+        Object.keys(clientAccounts).forEach(loginid => {
+            const account = clientAccounts[loginid];
+            accountsWithTokens[loginid] = { token: account.token };
+        });
+        const expires = new Date(new Date().getTime() + 1 * 60 * 1000); // 1 minute
+        Cookies.set('os_auth_tokens', JSON.stringify(accountsWithTokens), { domain: URLConstants.baseDomain, expires });
+        const params = new URLSearchParams({
+            action: 'real-account-signup',
+            ...(currency ? { currency } : {}),
+            target: landingCompany || LANDING_COMPANIES.MALTAINVEST,
+        });
+        const baseUrl = isProduction() ? OUT_SYSTEMS_TRADERSHUB.PRODUCTION : OUT_SYSTEMS_TRADERSHUB.STAGING;
+        const redirectURL = new URL(`${baseUrl}/redirect`);
+        redirectURL.search = params.toString();
+        return (window.location.href = redirectURL.toString());
+    }
+};

--- a/packages/core/src/Stores/ui-store.js
+++ b/packages/core/src/Stores/ui-store.js
@@ -5,7 +5,7 @@ import { Analytics } from '@deriv-com/analytics';
 
 import { MAX_MOBILE_WIDTH, MAX_TABLET_WIDTH } from 'Constants/ui';
 
-import { redirectToOutSystems } from './Helpers/redirectToOutSystems';
+import { isOutsystemsSupported, redirectToOutSystems } from './Helpers/redirectToOutSystems';
 import BaseStore from './base-store';
 
 const store_name = 'ui_store';
@@ -679,7 +679,7 @@ export default class UIStore extends BaseStore {
         );
 
         if (target) {
-            if (isOutSystemsRealAccountCreationEnabled) {
+            if (isOutSystemsRealAccountCreationEnabled && isOutsystemsSupported) {
                 redirectToOutSystems(target);
             } else {
                 this.is_real_acc_signup_on = true;

--- a/packages/core/src/Stores/ui-store.js
+++ b/packages/core/src/Stores/ui-store.js
@@ -1,9 +1,11 @@
 import { action, autorun, computed, makeObservable, observable } from 'mobx';
 
 import { isMobile, isTouchDevice, routes } from '@deriv/shared';
+import { Analytics } from '@deriv-com/analytics';
 
 import { MAX_MOBILE_WIDTH, MAX_TABLET_WIDTH } from 'Constants/ui';
 
+import { redirectToOutSystems } from './Helpers/redirectToOutSystems';
 import BaseStore from './base-store';
 
 const store_name = 'ui_store';
@@ -671,8 +673,17 @@ export default class UIStore extends BaseStore {
     }
 
     openRealAccountSignup(target) {
+        const isOutSystemsRealAccountCreationEnabled = Analytics?.getFeatureValue(
+            'trigger_os_real_account_creation',
+            false
+        );
+
         if (target) {
-            this.is_real_acc_signup_on = true;
+            if (isOutSystemsRealAccountCreationEnabled) {
+                redirectToOutSystems(target);
+            } else {
+                this.is_real_acc_signup_on = true;
+            }
             this.real_account_signup_target = target;
             this.is_accounts_switcher_on = false;
             localStorage.removeItem('current_question_index');

--- a/packages/core/src/Stores/ui-store.js
+++ b/packages/core/src/Stores/ui-store.js
@@ -673,10 +673,7 @@ export default class UIStore extends BaseStore {
     }
 
     openRealAccountSignup(target) {
-        const isOutSystemsRealAccountCreationEnabled = Analytics?.getFeatureValue(
-            'trigger_os_real_account_creation',
-            false
-        );
+        const isOutSystemsRealAccountCreationEnabled = Analytics?.getFeatureValue('dynamic_fa_os_real_account', false);
 
         if (target) {
             if (isOutSystemsRealAccountCreationEnabled && isOutsystemsSupported) {


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.

This PR introduces a feature flag that controls the redirection for real account creation. When the flag is enabled, all redirections will route to the Outsystems low-code real account creation page. If the flag is disabled, the redirection will open the real account creation modal in the high-code environment. This allows for easier testing and flexibility in transitioning between the two account creation methods.
