### PR TITLE
habib/[TRAH-5757]/add cookie mechanism for supporting wallets seamless login

### DIFF
--- a/packages/core/src/App/Components/Layout/Header/login-button.jsx
+++ b/packages/core/src/App/Components/Layout/Header/login-button.jsx
@@ -3,10 +3,9 @@ import PropTypes from 'prop-types';
 import Cookies from 'js-cookie';
 import { Button } from '@deriv/components';
 import { useOauth2 } from '@deriv/hooks';
-import { redirectToLogin } from '@deriv/shared';
+import { isStaging, redirectToLogin } from '@deriv/shared';
 import { getLanguage, localize } from '@deriv/translations';
 import { requestOidcAuthentication } from '@deriv-com/auth-client';
-import { isProduction } from '../config/config';
 
 const LoginButton = ({ className }) => {
     const { isOAuth2Enabled } = useOauth2({});
@@ -19,10 +18,10 @@ const LoginButton = ({ className }) => {
             text={localize('Log in')}
             onClick={async () => {
                 if (has_wallet_cookie) {
-                    if (isProduction()) {
-                        location.href = 'https://hub.deriv.com/tradershub/login';
-                    } else {
+                    if (isStaging) {
                         location.href = 'https://staging-hub.deriv.com/tradershub/login';
+                    } else {
+                        location.href = 'https://hub.deriv.com/tradershub/login';
                     }
                 }
                 if (isOAuth2Enabled) {

--- a/packages/core/src/App/Components/Layout/Header/login-button.jsx
+++ b/packages/core/src/App/Components/Layout/Header/login-button.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import Cookies from 'js-cookie';
 import { Button } from '@deriv/components';
 import { useOauth2 } from '@deriv/hooks';
 import { redirectToLogin } from '@deriv/shared';
 import { getLanguage, localize } from '@deriv/translations';
 import { requestOidcAuthentication } from '@deriv-com/auth-client';
+import { isProduction } from '../config/config';
 
 const LoginButton = ({ className }) => {
     const { isOAuth2Enabled } = useOauth2({});
+    const has_wallet_cookie = Cookies.get('wallet_account');
     return (
         <Button
             id='dt_login_button'
@@ -16,6 +18,13 @@ const LoginButton = ({ className }) => {
             has_effect
             text={localize('Log in')}
             onClick={async () => {
+                if (has_wallet_cookie) {
+                    if (isProduction()) {
+                        location.href = 'https://hub.deriv.com/tradershub/login';
+                    } else {
+                        location.href = 'https://staging-hub.deriv.com/tradershub/login';
+                    }
+                }
                 if (isOAuth2Enabled) {
                     await requestOidcAuthentication({
                         redirectCallbackUri: `${window.location.origin}/callback`,

--- a/packages/core/src/App/Containers/RootComponent/root-component.jsx
+++ b/packages/core/src/App/Containers/RootComponent/root-component.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
-
+import Cookies from 'js-cookie';
 import { useIsHubRedirectionEnabled, useOauth2 } from '@deriv/hooks';
-import { moduleLoader } from '@deriv/shared';
+import { moduleLoader, deriv_urls } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 
 const AppStore = React.lazy(() =>
@@ -67,6 +67,11 @@ const RootComponent = observer(props => {
             const url_query_string = window.location.search;
             const url_params = new URLSearchParams(url_query_string);
             const accountCurrency = url_params.get('account');
+
+            const domain = /deriv\.(com|me|be)/.test(window.location.hostname)
+                ? deriv_urls.DERIV_HOST_NAME
+                : window.location.hostname;
+            Cookies.set('wallet_account', true, { domain });
 
             switch (redirect_to_lowcode) {
                 case 'wallet':

--- a/packages/shared/src/utils/config/config.ts
+++ b/packages/shared/src/utils/config/config.ts
@@ -1,5 +1,6 @@
 import { isBot } from '../platform';
 import { isStaging } from '../url/helpers';
+
 /*
  * Configuration values needed in js codes
  *
@@ -55,7 +56,6 @@ export const getAppId = () => {
     window.localStorage.removeItem('config.platform'); // Remove config stored in localstorage if there's any.
     const platform = window.sessionStorage.getItem('config.platform');
     const is_bot = isBot();
-
     // Added platform at the top since this should take precedence over the config_app_id
     if (platform && platform_app_ids[platform as keyof typeof platform_app_ids]) {
         app_id = platform_app_ids[platform as keyof typeof platform_app_ids];

--- a/packages/shared/src/utils/config/config.ts
+++ b/packages/shared/src/utils/config/config.ts
@@ -1,5 +1,6 @@
 import { isBot } from '../platform';
 import { isStaging } from '../url/helpers';
+import Cookies from 'js-cookie';
 
 /*
  * Configuration values needed in js codes
@@ -56,6 +57,8 @@ export const getAppId = () => {
     window.localStorage.removeItem('config.platform'); // Remove config stored in localstorage if there's any.
     const platform = window.sessionStorage.getItem('config.platform');
     const is_bot = isBot();
+    const has_wallet_cookie = Cookies.get('wallet_account');
+
     // Added platform at the top since this should take precedence over the config_app_id
     if (platform && platform_app_ids[platform as keyof typeof platform_app_ids]) {
         app_id = platform_app_ids[platform as keyof typeof platform_app_ids];
@@ -69,6 +72,12 @@ export const getAppId = () => {
         app_id = is_bot ? 19112 : domain_app_ids[current_domain as keyof typeof domain_app_ids] || 16303; // it's being used in endpoint chrome extension - please do not remove
     } else if (/localhost/i.test(window.location.hostname)) {
         app_id = 36300;
+    } else if (has_wallet_cookie) {
+        if (isProduction()) {
+            app_id = 61554;
+        } else {
+            app_id = 53503;
+        }
     } else {
         window.localStorage.removeItem('config.default_app_id');
         app_id = is_bot ? 19111 : domain_app_ids[current_domain as keyof typeof domain_app_ids] || 16929;

--- a/packages/shared/src/utils/config/config.ts
+++ b/packages/shared/src/utils/config/config.ts
@@ -57,7 +57,6 @@ export const getAppId = () => {
     window.localStorage.removeItem('config.platform'); // Remove config stored in localstorage if there's any.
     const platform = window.sessionStorage.getItem('config.platform');
     const is_bot = isBot();
-    const has_wallet_cookie = Cookies.get('wallet_account');
 
     // Added platform at the top since this should take precedence over the config_app_id
     if (platform && platform_app_ids[platform as keyof typeof platform_app_ids]) {
@@ -72,12 +71,6 @@ export const getAppId = () => {
         app_id = is_bot ? 19112 : domain_app_ids[current_domain as keyof typeof domain_app_ids] || 16303; // it's being used in endpoint chrome extension - please do not remove
     } else if (/localhost/i.test(window.location.hostname)) {
         app_id = 36300;
-    } else if (has_wallet_cookie) {
-        if (isProduction()) {
-            app_id = 61554;
-        } else {
-            app_id = 53503;
-        }
     } else {
         window.localStorage.removeItem('config.default_app_id');
         app_id = is_bot ? 19111 : domain_app_ids[current_domain as keyof typeof domain_app_ids] || 16929;
@@ -126,6 +119,15 @@ export const checkAndSetEndpointFromUrl = () => {
 
             const params = url_params.toString();
             const hash = location.hash;
+
+            const has_wallet_cookie = Cookies.get('wallet_account');
+            if (has_wallet_cookie) {
+                if (isProduction()) {
+                    location.href = 'https://hub.deriv.com/tradershub/login';
+                } else {
+                    location.href = 'https://staging-hub.deriv.com/tradershub/login';
+                }
+            }
 
             location.href = `${location.protocol}//${location.hostname}${location.pathname}${
                 params ? `?${params}` : ''

--- a/packages/shared/src/utils/config/config.ts
+++ b/packages/shared/src/utils/config/config.ts
@@ -1,7 +1,5 @@
 import { isBot } from '../platform';
 import { isStaging } from '../url/helpers';
-import Cookies from 'js-cookie';
-
 /*
  * Configuration values needed in js codes
  *
@@ -119,15 +117,6 @@ export const checkAndSetEndpointFromUrl = () => {
 
             const params = url_params.toString();
             const hash = location.hash;
-
-            const has_wallet_cookie = Cookies.get('wallet_account');
-            if (has_wallet_cookie) {
-                if (isProduction()) {
-                    location.href = 'https://hub.deriv.com/tradershub/login';
-                } else {
-                    location.href = 'https://staging-hub.deriv.com/tradershub/login';
-                }
-            }
 
             location.href = `${location.protocol}//${location.hostname}${location.pathname}${
                 params ? `?${params}` : ''

--- a/packages/shared/src/utils/login/login.ts
+++ b/packages/shared/src/utils/login/login.ts
@@ -1,9 +1,8 @@
 import { website_name } from '../config/app-config';
-import { domain_app_ids, getAppId, isProduction } from '../config/config';
+import { domain_app_ids, getAppId } from '../config/config';
 import { CookieStorage, isStorageSupported, LocalStore } from '../storage/storage';
 import { getStaticUrl, urlForCurrentDomain } from '../url';
 import { deriv_urls } from '../url/constants';
-import Cookies from 'js-cookie';
 
 export const redirectToLogin = (is_logged_in: boolean, language: string, has_params = true, redirect_delay = 0) => {
     if (!is_logged_in && isStorageSupported(sessionStorage)) {
@@ -37,15 +36,6 @@ export const loginUrl = ({ language }: TLoginUrl) => {
     const marketing_queries = `${signup_device ? `&signup_device=${signup_device}` : ''}${
         date_first_contact ? `&date_first_contact=${date_first_contact}` : ''
     }`;
-
-    const has_wallet_cookie = Cookies.get('wallet_account');
-    if (has_wallet_cookie) {
-        if (isProduction()) {
-            location.href = 'https://hub.deriv.com/tradershub/login';
-        } else {
-            location.href = 'https://staging-hub.deriv.com/tradershub/login';
-        }
-    }
 
     const getOAuthUrl = () => {
         return `https://oauth.${

--- a/packages/shared/src/utils/login/login.ts
+++ b/packages/shared/src/utils/login/login.ts
@@ -1,8 +1,9 @@
 import { website_name } from '../config/app-config';
-import { domain_app_ids, getAppId } from '../config/config';
+import { domain_app_ids, getAppId, isProduction } from '../config/config';
 import { CookieStorage, isStorageSupported, LocalStore } from '../storage/storage';
 import { getStaticUrl, urlForCurrentDomain } from '../url';
 import { deriv_urls } from '../url/constants';
+import Cookies from 'js-cookie';
 
 export const redirectToLogin = (is_logged_in: boolean, language: string, has_params = true, redirect_delay = 0) => {
     if (!is_logged_in && isStorageSupported(sessionStorage)) {
@@ -36,6 +37,16 @@ export const loginUrl = ({ language }: TLoginUrl) => {
     const marketing_queries = `${signup_device ? `&signup_device=${signup_device}` : ''}${
         date_first_contact ? `&date_first_contact=${date_first_contact}` : ''
     }`;
+
+    const has_wallet_cookie = Cookies.get('wallet_account');
+    if (has_wallet_cookie) {
+        if (isProduction()) {
+            location.href = 'https://hub.deriv.com/tradershub/login';
+        } else {
+            location.href = 'https://staging-hub.deriv.com/tradershub/login';
+        }
+    }
+
     const getOAuthUrl = () => {
         return `https://oauth.${
             deriv_urls.DERIV_HOST_NAME


### PR DESCRIPTION
## Changes:

After the first login, we can store a cookie on “.[deriv.com](http://deriv.com/)” with the value wallets=true.
When the user clicks the login button on [deriv.com](http://deriv.com/) or [app.deriv.com](http://app.deriv.com/), the system checks this cookie value and growthbook feature flag.

Based on the cookie, we dynamically alter the app IDs and redirect the user to the appropriate domain:
If wallets are enabled, redirect to [hub.deriv.com](http://hub.deriv.com/).
Otherwise, redirect to [app.deriv.com](http://app.deriv.com/).
