### PR TITLE
chore: rename classname to avoid double classname override

### DIFF
--- a/packages/core/src/App/AppContent.tsx
+++ b/packages/core/src/App/AppContent.tsx
@@ -174,15 +174,15 @@ const AppContent: React.FC<{ passthrough: unknown }> = observer(({ passthrough }
             <LandscapeBlocker />
             {!isCallBackPage && !is_single_logging_in && <Header />}
             {is_single_logging_in && (
-                <div className='callback'>
-                    <div className='callback__content'>
+                <div className='initial-callback'>
+                    <div className='initial-callback__content'>
                         <img
                             src={getUrlBase('/public/images/common/callback_loader.gif')}
                             width={234}
                             height={234}
                             alt='loader'
                         />
-                        <h3 className='callback__title'>{localize('Getting your account ready')}</h3>
+                        <h3 className='initial-callback__title'>{localize('Getting your account ready')}</h3>
                     </div>
                 </div>
             )}

--- a/packages/core/src/sass/app.scss
+++ b/packages/core/src/sass/app.scss
@@ -32,7 +32,7 @@
 @import 'app/_common/components/account-common';
 @import 'app/_common/components/wallet';
 @import 'app/_common/components/cfd-poa';
-@import 'app/_common/components/callback';
+@import 'app/_common/components/initial-callback';
 // Modules
 @import 'app/modules/page-404';
 @import 'app/modules/account-closed';

--- a/packages/core/src/sass/app/_common/components/initial-callback.scss
+++ b/packages/core/src/sass/app/_common/components/initial-callback.scss
@@ -1,4 +1,4 @@
-.callback {
+.initial-callback {
     font-family: 'Ubuntu', sans-serif;
     height: 100vh;
     width: 100vw;


### PR DESCRIPTION
## Changes:

callback classname is being used by callback page which apply double margin

