### PR TITLE
[CFDS] shontzu/CFDS-3449/shortcode-and-region-label

### DIFF
--- a/packages/core/src/Stores/traders-hub-store.js
+++ b/packages/core/src/Stores/traders-hub-store.js
@@ -824,11 +824,7 @@ export default class TradersHubStore extends BaseStore {
                     ? account.landing_company_short?.charAt(0).toUpperCase() + account.landing_company_short?.slice(1)
                     : account.landing_company_short?.toUpperCase();
 
-            let region = '';
-            if (this.hasMultipleSVGAccounts()) {
-                region = '';
-            }
-            short_code_and_region = `${short_code}${region}`;
+            short_code_and_region = `${short_code}`;
         }
         return short_code_and_region;
     }

--- a/packages/core/src/Stores/traders-hub-store.js
+++ b/packages/core/src/Stores/traders-hub-store.js
@@ -826,10 +826,7 @@ export default class TradersHubStore extends BaseStore {
 
             let region = '';
             if (this.hasMultipleSVGAccounts()) {
-                region =
-                    account.market_type !== 'financial' && account.landing_company_short !== 'bvi'
-                        ? ` - ${this.getServerName(account)}`
-                        : '';
+                region = '';
             }
             short_code_and_region = `${short_code}${region}`;
         }


### PR DESCRIPTION
## Changes:
- update `shortcode_and_region` badge to just `shortcode`
- ❌ `SVG - Asia`  `SVG - Africa`  `SVG - Europe`  `Vanuatu`
- ✅ `SVG`  `SVG`  `SVG`  `Vanuatu`
- Check in Tradershub dashboard
- Check in Transfers modal

### Screenshots:

Before:
![image](https://github.com/user-attachments/assets/db1297c4-5427-4180-9289-1d4ef1cf1d53)

After:
![image](https://github.com/user-attachments/assets/3ac9dd48-5c5f-42b1-9533-232164127906)
