### PR TITLE
GRWT-5433 / Kate / Inconsistency of 'ticks' and 'tick' for Tick duration

### DIFF
--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
@@ -36,7 +36,7 @@ const Duration = observer(({ is_minimized }: TTradeParametersProps) => {
     } = useTraderStore();
     const { addSnackbar } = useSnackbar();
     const { name_plural, name, name_singular } = getUnitMap()[duration_unit] ?? {};
-    const duration_unit_text = duration_unit === 't' && duration === 1 ? name_singular : (name_plural ?? name);
+    const duration_unit_text = (duration === 1 ? name_singular : name_plural) ?? name;
     const [selected_hour, setSelectedHour] = useState<number[]>([]);
     const [is_open, setOpen] = useState(false);
     const [expiry_time_string, setExpiryTimeString] = useState('');
@@ -117,7 +117,7 @@ const Duration = observer(({ is_minimized }: TTradeParametersProps) => {
             if (duration_unit === 'm' && duration > 59) {
                 const hours = Math.floor(duration / 60);
                 const minutes = duration % 60;
-                return `${hours} ${localize('hours')} ${minutes ? `${minutes} ${localize('minutes')}` : ''} `;
+                return `${hours} ${hours > 1 ? localize('hours') : localize('hour')} ${minutes ? `${minutes} ${minutes > 1 ? localize('minutes') : localize('minute')}` : ''} `;
             } else if (duration_unit === 'd') {
                 if (!formatted_date) {
                     return '';

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
@@ -35,8 +35,8 @@ const Duration = observer(({ is_minimized }: TTradeParametersProps) => {
         validation_errors,
     } = useTraderStore();
     const { addSnackbar } = useSnackbar();
-    const { name_plural, name } = getUnitMap()[duration_unit] ?? {};
-    const duration_unit_text = name_plural ?? name;
+    const { name_plural, name, name_singular } = getUnitMap()[duration_unit] ?? {};
+    const duration_unit_text = duration_unit === 't' && duration === 1 ? name_singular : (name_plural ?? name);
     const [selected_hour, setSelectedHour] = useState<number[]>([]);
     const [is_open, setOpen] = useState(false);
     const [expiry_time_string, setExpiryTimeString] = useState('');

--- a/packages/trader/src/AppV2/Utils/__tests__/trade-param-utils.spec.tsx
+++ b/packages/trader/src/AppV2/Utils/__tests__/trade-param-utils.spec.tsx
@@ -339,7 +339,7 @@ describe('getOptionPerUnit', () => {
         const result = getOptionPerUnit('t', duration_min_max);
         const view = renderOptions(result[0]);
         expect(result).toHaveLength(1);
-        expect(view).toEqual([...Array(6)].map((_, i) => `${i + 5} tick`));
+        expect(view).toEqual([...Array(6)].map((_, i) => `${i + 5} ticks`));
     });
 
     test('returns correct options for ticks (t) when 5 ticks are required', () => {
@@ -347,7 +347,7 @@ describe('getOptionPerUnit', () => {
         const result = getOptionPerUnit('t', modifiedDuration);
         const view = renderOptions(result[0]);
         expect(result).toHaveLength(1);
-        expect(view).toEqual([...Array(10)].map((_, i) => `${i + 1} tick`));
+        expect(view).toEqual([...Array(10)].map((_, i) => `${i + 1} ${i + 1 > 1 ? 'ticks' : 'tick'}`));
     });
 });
 

--- a/packages/trader/src/AppV2/Utils/trade-params-utils.tsx
+++ b/packages/trader/src/AppV2/Utils/trade-params-utils.tsx
@@ -256,45 +256,61 @@ export const getClosestTimeToCurrentGMT = (interval: number): string => {
     return `${newHours}:${newMinutes}`;
 };
 
-export const getOptionPerUnit = (
-    unit: string,
-    duration_min_max: Record<string, { min: number; max: number }>
-): { value: number; label: React.ReactNode }[][] => {
-    const generateOptions = (start: number, end: number, label: React.ReactNode) => {
-        return Array.from({ length: end - start + 1 }, (_, i) => ({
-            value: start + i,
+type TDurationOption = {
+    value: number;
+    label: React.ReactNode;
+};
+
+const generateOptions = (
+    startValue: number,
+    endValue: number,
+    singularLabel: React.ReactNode,
+    pluralLabel: React.ReactNode
+): TDurationOption[] => {
+    const length = endValue - startValue + 1;
+    return Array.from({ length }, (_, index): TDurationOption => {
+        const value = startValue + index;
+        return {
+            value,
             label: (
-                <React.Fragment key={start + i}>
-                    {start + i} {label}
+                <React.Fragment key={value}>
+                    {value} {value > 1 ? pluralLabel : singularLabel}
                 </React.Fragment>
             ),
-        }));
-    };
+        };
+    });
+};
 
+export const getOptionPerUnit = (unit: string, duration_min_max: Record<string, { min: number; max: number }>) => {
     const { intraday, tick, daily } = duration_min_max;
     const unitConfig: Record<
         string,
-        { start: number; end: number; label: React.ReactNode } | (() => { value: number; label: React.ReactNode }[][])
+        | { start: number; end: number; labelSingle: React.ReactNode; labelPlural: React.ReactNode }
+        | (() => { value: number; label: React.ReactNode }[][])
     > = {
         m: {
             start: Math.max(1, intraday?.min / 60),
             end: Math.min(59, intraday?.max / 60),
-            label: <Localize i18n_default_text='min' />,
+            labelSingle: <Localize i18n_default_text='min' />,
+            labelPlural: <Localize i18n_default_text='min' />,
         },
         s: {
             start: Math.max(15, intraday?.min),
             end: Math.min(59, intraday?.max),
-            label: <Localize i18n_default_text='sec' />,
+            labelSingle: <Localize i18n_default_text='sec' />,
+            labelPlural: <Localize i18n_default_text='sec' />,
         },
         d: {
             start: Math.max(1, daily?.min / 86400),
             end: Math.min(365, daily?.max / 86400),
-            label: <Localize i18n_default_text='days' />,
+            labelSingle: <Localize i18n_default_text='days' />,
+            labelPlural: <Localize i18n_default_text='days' />,
         },
         t: {
             start: Math.max(1, tick?.min),
             end: Math.min(10, tick?.max),
-            label: <Localize i18n_default_text='tick' />,
+            labelSingle: <Localize i18n_default_text='tick' />,
+            labelPlural: <Localize i18n_default_text='ticks' />,
         },
     };
 
@@ -305,8 +321,8 @@ export const getOptionPerUnit = (
     }
 
     if (config) {
-        const { start, end, label } = config;
-        return [generateOptions(Math.ceil(start), Math.floor(end), label)];
+        const { start, end, labelSingle, labelPlural } = config;
+        return [generateOptions(Math.ceil(start), Math.floor(end), labelSingle, labelPlural)];
     }
 
     return [[]];


### PR DESCRIPTION
## Changes:

Fix ticks naming. For plural  - ticks, for single - tick.
Refactored utility functions in packages/trader/src/AppV2/Utils/trade-params-utils.tsx.
Refactored tests.

NOTE: For the duration field, changed 1 ticks to 1 tick, 1 minutes to 1 minute, 1 hours to 1 hour.

### Screenshots:

![Screenshot 2025-03-27 at 12 42 25 PM](https://github.com/user-attachments/assets/5a7095a2-5028-47be-b4eb-9057478a036f)
![Screenshot 2025-03-27 at 12 42 30 PM](https://github.com/user-attachments/assets/b56b18fd-58bb-4990-bf6b-3af81e32a31f)
![Screenshot 2025-03-27 at 12 42 36 PM](https://github.com/user-attachments/assets/8908fb7e-cbfd-4dce-b38d-f515838c412d)

