### PR TITLE
GRWT-5438 / Kate / Positioned Account loader for DTrader properly

### DIFF
--- a/packages/core/src/sass/app/_common/components/account-switcher.scss
+++ b/packages/core/src/sass/app/_common/components/account-switcher.scss
@@ -67,7 +67,7 @@
             width: 9rem;
         }
         @include mobile-screen {
-            width: 14rem;
+            width: 23rem;
             height: 4rem;
             top: -0.3rem;
 
@@ -243,7 +243,9 @@
         @include tablet-screen {
             position: unset;
         }
-        transition: transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1), opacity 0.25s linear;
+        transition:
+            transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1),
+            opacity 0.25s linear;
         box-shadow: 0 8px 16px 0 var(--shadow-menu);
         right: 0;
         top: calc(100% + 4px);


### PR DESCRIPTION
## Changes:

Increased width of the loader in DTrader account switcher in order to position it properly and hide data below it

### Screenshots:

![Screenshot 2025-03-27 at 2 22 46 PM](https://github.com/user-attachments/assets/da6d8a06-c265-44df-b1d6-fa05de5b3cca)
