### PR TITLE
Akmal / fix: enhance multipliers deal cancellation info layout and visibility handling

### DIFF
--- a/packages/trader/src/AppV2/Components/TradeParameters/MultipliersDealCancellationInfo/__tests__/multipliers-deal-cancellation-info.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/MultipliersDealCancellationInfo/__tests__/multipliers-deal-cancellation-info.spec.tsx
@@ -47,15 +47,15 @@ describe('MultipliersDealCancellationInfo', () => {
         default_mock_store.modules.trade.proposal_info = {};
         mockMultipliersDealCancellationInfo();
 
-        expect(screen.getByTestId('dt_skeleton')).toBeInTheDocument();
+        expect(screen.getAllByTestId('dt_skeleton')).toHaveLength(2);
     });
 
     it('renders component with title and value', () => {
         mockMultipliersDealCancellationInfo();
 
-        const title = screen.getByText('Deal cancellation fee');
-        expect(title).toBeInTheDocument();
-        expect(title).not.toHaveClass('trade-params__text--disabled');
+        const upTitle = screen.getByText('DC fee (Up)');
+        expect(upTitle).toBeInTheDocument();
+        expect(upTitle).not.toHaveClass('trade-params__text--disabled');
         expect(screen.getByText(/4.00 USD/)).toBeInTheDocument();
     });
 
@@ -63,6 +63,6 @@ describe('MultipliersDealCancellationInfo', () => {
         default_mock_store.modules.trade.is_market_closed = true;
         mockMultipliersDealCancellationInfo();
 
-        expect(screen.getByText('Deal cancellation fee')).toHaveClass('trade-params__text--disabled');
+        expect(screen.getByText('DC fee (Up)')).toHaveClass('trade-params__text--disabled');
     });
 });

--- a/packages/trader/src/AppV2/Components/TradeParameters/MultipliersDealCancellationInfo/multipliers-deal-cancellation-info.scss
+++ b/packages/trader/src/AppV2/Components/TradeParameters/MultipliersDealCancellationInfo/multipliers-deal-cancellation-info.scss
@@ -1,6 +1,45 @@
 .multipliers-info {
+    &__container {
+        display: flex;
+        width: 100%;
+
+        &--stacked {
+            flex-direction: column;
+
+            .multipliers-info__row {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                padding: 0 0 0.4rem;
+            }
+        }
+
+        &--horizontal {
+            flex-direction: row;
+            justify-content: space-between;
+            width: 100%;
+            padding: 0 0.4rem;
+
+            .multipliers-info__fee-row {
+                display: flex;
+                flex-direction: row;
+                justify-content: space-between;
+                align-items: center;
+                width: 48%;
+            }
+        }
+    }
+
     &__row {
         display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0 0 0.4rem;
+    }
+
+    &__fee-row {
+        display: flex;
+        flex-direction: row;
         justify-content: space-between;
         align-items: center;
     }

--- a/packages/trader/src/AppV2/Components/TradeParameters/MultipliersDealCancellationInfo/multipliers-deal-cancellation-info.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/MultipliersDealCancellationInfo/multipliers-deal-cancellation-info.tsx
@@ -7,27 +7,71 @@ import { Text } from '@deriv-com/quill-ui';
 import { useTraderStore } from 'Stores/useTraderStores';
 import { CONTRACT_TYPES } from '@deriv/shared';
 
-const MultipliersDealCancellationInfo = observer(() => {
+type TMultipliersDealCancellationInfoProps = {
+    is_minimized?: boolean;
+};
+
+const MultipliersDealCancellationInfo = observer(({ is_minimized }: TMultipliersDealCancellationInfoProps) => {
     const { currency, is_market_closed, proposal_info } = useTraderStore();
-    const deal_cancellation_fee_value = proposal_info?.[CONTRACT_TYPES.MULTIPLIER.UP]?.cancellation?.ask_price;
+
+    const up_deal_cancellation_fee = proposal_info?.[CONTRACT_TYPES.MULTIPLIER.UP]?.cancellation?.ask_price;
+    const down_deal_cancellation_fee = proposal_info?.[CONTRACT_TYPES.MULTIPLIER.DOWN]?.cancellation?.ask_price;
+
     const has_error =
         proposal_info?.[CONTRACT_TYPES.MULTIPLIER.UP]?.has_error ||
         proposal_info?.[CONTRACT_TYPES.MULTIPLIER.DOWN]?.has_error;
 
     if (has_error) return null;
 
+    const renderFeeValue = (fee_value?: number) => {
+        return fee_value ? (
+            <Money amount={fee_value} show_currency currency={currency} />
+        ) : (
+            <Skeleton width={65} height={18} />
+        );
+    };
+
+    if (is_minimized) {
+        return (
+            <div className='multipliers-info__container multipliers-info__container--horizontal'>
+                <div className='multipliers-info__fee-row'>
+                    <Text size='sm' className={clsx(is_market_closed && 'trade-params__text--disabled')}>
+                        <Localize i18n_default_text='DC Fee' />
+                    </Text>
+                    <Text size='sm' bold as='div' className={clsx(is_market_closed && 'trade-params__text--disabled')}>
+                        {renderFeeValue(up_deal_cancellation_fee)}
+                    </Text>
+                </div>
+                <div className='multipliers-info__fee-row'>
+                    <Text size='sm' className={clsx(is_market_closed && 'trade-params__text--disabled')}>
+                        <Localize i18n_default_text='DC Fee' />
+                    </Text>
+                    <Text size='sm' bold as='div' className={clsx(is_market_closed && 'trade-params__text--disabled')}>
+                        {renderFeeValue(down_deal_cancellation_fee)}
+                    </Text>
+                </div>
+            </div>
+        );
+    }
+
     return (
-        <div className='multipliers-info__row'>
-            <Text size='sm' className={clsx(is_market_closed && 'trade-params__text--disabled')}>
-                <Localize i18n_default_text='Deal cancellation fee' />
-            </Text>
-            <Text size='sm' bold as='div' className={clsx(is_market_closed && 'trade-params__text--disabled')}>
-                {deal_cancellation_fee_value ? (
-                    <Money amount={deal_cancellation_fee_value} show_currency currency={currency} />
-                ) : (
-                    <Skeleton width={65} height={18} />
-                )}
-            </Text>
+        <div className='multipliers-info__container multipliers-info__container--stacked'>
+            <div className='multipliers-info__row'>
+                <Text size='sm' className={clsx(is_market_closed && 'trade-params__text--disabled')}>
+                    <Localize i18n_default_text='DC fee (Up)' />
+                </Text>
+                <Text size='sm' bold as='div' className={clsx(is_market_closed && 'trade-params__text--disabled')}>
+                    {renderFeeValue(up_deal_cancellation_fee)}
+                </Text>
+            </div>
+            <div className='multipliers-info__row'>
+                <Text size='sm' className={clsx(is_market_closed && 'trade-params__text--disabled')}>
+                    <Localize i18n_default_text='DC fee (Down)' />
+                </Text>
+                <Text size='sm' bold as='div' className={clsx(is_market_closed && 'trade-params__text--disabled')}>
+                    {renderFeeValue(down_deal_cancellation_fee)}
+                </Text>
+            </div>
         </div>
     );
 });

--- a/packages/trader/src/AppV2/Components/TradeParameters/trade-parameters.scss
+++ b/packages/trader/src/AppV2/Components/TradeParameters/trade-parameters.scss
@@ -42,7 +42,7 @@
 
             &--minimized {
                 max-height: 104px;
-                padding: var(--core-spacing-400) var(--core-spacing-400) var(--core-spacing-400) var(--core-spacing-400);
+                padding: var(--core-spacing-400) var(--core-spacing-400) var(--core-spacing-200) var(--core-spacing-400);
 
                 .quill-input__container {
                     width: unset;

--- a/packages/trader/src/AppV2/Components/TradeParameters/trade-parameters.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/trade-parameters.tsx
@@ -41,7 +41,6 @@ const TradeParameters = observer(({ is_minimized }: TTradeParametersProps) => {
             {is_minimized && (
                 <React.Fragment>
                     {isVisible('expiration') && <MultipliersExpirationInfo />}
-                    {isVisible('mult_info_display') && <MultipliersDealCancellationInfo />}
                     {isVisible('payout_per_point_info') && <PayoutPerPointInfo />}
                     {isVisible('allow_equals') && <AllowEquals />}
                     {isVisible('payout') && <PayoutInfo />}
@@ -70,8 +69,8 @@ const TradeParameters = observer(({ is_minimized }: TTradeParametersProps) => {
                 {isVisible('barrier_info') && !is_minimized && <BarrierInfo />}
                 {isVisible('payout_per_point_info') && !is_minimized && <PayoutPerPointInfo />}
                 {isVisible('payout') && !is_minimized && <PayoutInfo />}
-                {isVisible('mult_info_display') && !is_minimized && <MultipliersDealCancellationInfo />}
             </div>
+            {isVisible('mult_info_display') && <MultipliersDealCancellationInfo is_minimized={is_minimized} />}
         </div>
     );
 });


### PR DESCRIPTION
This PR addresses an issue with the display of Deal Cancellation fees in Multiplier contracts. Previously, in the mobile/responsive view, only the UP contract's cancellation fee was displayed, while the desktop view correctly showed both UP and DOWN fees. This inconsistency affected the Stake value displayed on the purchase buttons.

Changes
Updated MultipliersDealCancellationInfo component:

-Modified the component to display both UP and DOWN cancellation fees in a horizontal layout
-Ensured the "DC Fee" label and value are displayed on the same line
-Maintained proper spacing and alignment between elements

Updated CSS styling:

- Added styles for the horizontal layout with proper spacing
- Created fee-row class to display label and value side by side
- Added appropriate padding and margins to match the design

Improved component positioning:

- Moved the deal cancellation section to be positioned right above the purchase buttons
- Ensured consistent display in both minimized and non-minimized views
- Unified the component implementation to work with both display modes

<img width="459" alt="image" src="https://github.com/user-attachments/assets/40a76e86-6683-405f-9080-9861993c988f" />
