### PR TITLE
GRWT-5431 / Kate / [DTrader] Text cursor is behind the currency for Take profit, Stoploss in Arabic language

### DIFF
--- a/packages/trader/src/sass/app/modules/trading.scss
+++ b/packages/trader/src/sass/app/modules/trading.scss
@@ -575,6 +575,7 @@
                 direction: rtl;
             }
             & .dc-input-wrapper {
+                direction: ltr;
                 border: 1px solid var(--status-danger);
 
                 &:hover {


### PR DESCRIPTION
## Changes:

Add css fix for selective ignoring rtl

### Screenshots:


https://github.com/user-attachments/assets/7b8df391-5695-456d-9848-09495b0627ea


