### PR TITLE
shontzu/TRAH-6048/CFDs-loss-percentage-update-for-EU-in-bottom-disclaimer

### DIFF
--- a/packages/appstore/src/components/disclaimer/disclaimer.tsx
+++ b/packages/appstore/src/components/disclaimer/disclaimer.tsx
@@ -10,7 +10,7 @@ const Disclaimer = () => {
     return (
         <div data-testid='dt_traders_hub_disclaimer' className='disclaimer'>
             <Text align='left' className='disclaimer-text' size={!isDesktop ? 'xxxs' : 'xs'}>
-                <Localize i18n_default_text='The products offered on our website are complex derivative products that carry a significant risk of potential loss. CFDs are complex instruments with a high risk of losing money rapidly due to leverage. 70% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether you understand how these products work and whether you can afford to take the high risk of losing your money.' />
+                <Localize i18n_default_text='The products offered on our website are complex derivative products that carry a significant risk of potential loss. CFDs are complex instruments with a high risk of losing money rapidly due to leverage. 72% of retail investor accounts lose money when trading CFDs with this provider. You should consider whether you understand how these products work and whether you can afford to take the high risk of losing your money.' />
             </Text>
             <div className='disclaimer__bottom-plug' />
         </div>

--- a/packages/wallets/src/components/WalletsDisclaimerBanner/WalletsDisclaimerBanner.tsx
+++ b/packages/wallets/src/components/WalletsDisclaimerBanner/WalletsDisclaimerBanner.tsx
@@ -12,7 +12,7 @@ const WalletsMobileDisclaimerBannerContent = () => {
                 <Text size='xs'>
                     <Localize
                         components={[<strong key={0} />]}
-                        i18n_default_text='The products offered on our website are complex derivative products that carry a significant risk of potential loss. CFDs are complex instruments with a high risk of losing money rapidly due to leverage. <0>70% of retail investor accounts lose money when trading CFDs with this provider.</0> You should consider whether you understand how these products work and whether you can afford to take the high risk of losing your money.'
+                        i18n_default_text='The products offered on our website are complex derivative products that carry a significant risk of potential loss. CFDs are complex instruments with a high risk of losing money rapidly due to leverage. <0>72% of retail investor accounts lose money when trading CFDs with this provider.</0> You should consider whether you understand how these products work and whether you can afford to take the high risk of losing your money.'
                     />
                 </Text>
                 <div className='wallets-disclaimer-banner__content__icon'>
@@ -24,7 +24,7 @@ const WalletsMobileDisclaimerBannerContent = () => {
     return (
         <>
             <Text size='xs' weight='bold'>
-                <Localize i18n_default_text='70.78% of retail investor accounts lose money when trading CFDs with this provider. ' />
+                <Localize i18n_default_text='72% of retail investor accounts lose money when trading CFDs with this provider. ' />
             </Text>
             <div className='wallets-disclaimer-banner__content__icon'>
                 <LabelPairedChevronUpLgBoldIcon height={16} onClick={() => setIsOpen(true)} width={16} />
@@ -43,7 +43,7 @@ const WalletsDisclaimerBanner = () => {
                         <Text size='sm'>
                             <Localize
                                 components={[<strong key={0} />]}
-                                i18n_default_text='The products offered on our website are complex derivative products that carry a significant risk of potential loss. CFDs are complex instruments with a high risk of losing money rapidly due to leverage. <0>70% of retail investor accounts lose money when trading CFDs with this provider.</0> You should consider whether you understand how these products work and whether you can afford to take the high risk of losing your money.'
+                                i18n_default_text='The products offered on our website are complex derivative products that carry a significant risk of potential loss. CFDs are complex instruments with a high risk of losing money rapidly due to leverage. <0>72% of retail investor accounts lose money when trading CFDs with this provider.</0> You should consider whether you understand how these products work and whether you can afford to take the high risk of losing your money.'
                             />
                         </Text>
                     ) : (


### PR DESCRIPTION
## Changes:

content update (70% to 72%) [[thread]](https://deriv-group.slack.com/archives/C076SGRD28H/p1743692128468399)

We need to have the CFD loss percentage updated to 72% to reflect Q1 2025 on the [app.deriv.com](http://app.deriv.com/) domain for EU clients as part of the MFSA regulatory requirements.

### Screenshots:

![image](https://github.com/user-attachments/assets/0cca353c-e7ef-41c0-a19b-eee9de7a733f)

