### PR TITLE
Aizad/TRAH-5988/[Onboarding] (i) icon overlapped with the selected currency square box line

### DIFF
--- a/packages/core/src/App/Containers/RealAccountSignup/currency-selector.scss
+++ b/packages/core/src/App/Containers/RealAccountSignup/currency-selector.scss
@@ -26,6 +26,7 @@
         }
     }
     &__item {
+        position: relative;
         align-items: center;
         border-radius: 8px;
         display: inline-flex;
@@ -96,15 +97,9 @@
         display: none;
     }
     &__popover {
-        position: relative;
-        left: 4.8rem;
-        top: -4.8rem;
-        margin-top: -16px;
-
-        @include mobile-or-tablet-screen {
-            right: 0;
-            top: -5.8rem;
-        }
+        position: absolute;
+        top: 0.8rem;
+        right: 0.8rem;
     }
 
     &__loading-wrapper {

--- a/packages/core/src/App/Containers/RealAccountSignup/currency-selector.scss
+++ b/packages/core/src/App/Containers/RealAccountSignup/currency-selector.scss
@@ -99,7 +99,7 @@
     &__popover {
         position: absolute;
         top: 0.8rem;
-        right: 0.8rem;
+        inset-inline-end: 0.8rem;
     }
 
     &__loading-wrapper {


### PR DESCRIPTION
## Changes:
- Made small CSS changes to account currency popover tooltip icon.

### Screenshots:
**Before:**
![image](https://github.com/user-attachments/assets/34444641-7ea7-46ef-aab2-3b332e1da45a)
**After**
![image](https://github.com/user-attachments/assets/db76fff3-7db4-4836-9dbd-5320ecedd2db)
![image](https://github.com/user-attachments/assets/55613e19-0ccd-42a2-8d47-4987a42da092)
![image](https://github.com/user-attachments/assets/e3137456-3eda-4275-a3c1-274ddaa838a6)


