### PR TITLE
GRWT-5552 / Kate / [DTrader] End time showing wrongly while user switch from Duration to End time for Rise/Fall

### DIFF
--- a/packages/shared/src/utils/date/__tests__/date-time.spec.ts
+++ b/packages/shared/src/utils/date/__tests__/date-time.spec.ts
@@ -136,3 +136,58 @@ describe('getDateFromTimestamp', () => {
         expect(DateTime.getDateFromTimestamp(1814966400)).toEqual('07 07 2027');
     });
 });
+
+describe('getTomorrowDate', () => {
+    it("should return tomorrow's date in YYYY-MM-DD format", () => {
+        const server_time = '2025-04-08 09:28:52';
+        const expected_tomorrow = '2025-04-09';
+
+        expect(DateTime.getTomorrowDate(server_time)).toBe(expected_tomorrow);
+    });
+
+    it('should handle different input formats', () => {
+        const date_object = new Date('2025-04-08T09:28:52');
+        const expected_tomorrow = '2025-04-09';
+
+        expect(DateTime.getTomorrowDate(date_object)).toBe(expected_tomorrow);
+    });
+
+    it('should handle month rollover', () => {
+        const server_time = '2025-04-30 09:28:52';
+        const expected_tomorrow = '2025-05-01';
+
+        expect(DateTime.getTomorrowDate(server_time)).toBe(expected_tomorrow);
+    });
+});
+
+describe('getTomorrowAsDate', () => {
+    it("should return tomorrow's date as Date object", () => {
+        const server_time = '2025-04-08 09:28:52';
+        const result = DateTime.getTomorrowAsDate(server_time);
+
+        expect(result).toBeInstanceOf(Date);
+        expect(result.getFullYear()).toBe(2025);
+        expect(result.getMonth()).toBe(3); // April is 3 (0-based)
+        expect(result.getDate()).toBe(9);
+    });
+
+    it('should handle different input formats', () => {
+        const date_object = new Date('2025-04-08T09:28:52');
+        const result = DateTime.getTomorrowAsDate(date_object);
+
+        expect(result).toBeInstanceOf(Date);
+        expect(result.getFullYear()).toBe(2025);
+        expect(result.getMonth()).toBe(3);
+        expect(result.getDate()).toBe(9);
+    });
+
+    it('should handle month rollover', () => {
+        const server_time = '2025-04-30 09:28:52';
+        const result = DateTime.getTomorrowAsDate(server_time);
+
+        expect(result).toBeInstanceOf(Date);
+        expect(result.getFullYear()).toBe(2025);
+        expect(result.getMonth()).toBe(4); // May is 4 (0-based)
+        expect(result.getDate()).toBe(1);
+    });
+});

--- a/packages/shared/src/utils/date/__tests__/date-time.spec.ts
+++ b/packages/shared/src/utils/date/__tests__/date-time.spec.ts
@@ -159,35 +159,3 @@ describe('getTomorrowDate', () => {
         expect(DateTime.getTomorrowDate(server_time)).toBe(expected_tomorrow);
     });
 });
-
-describe('getTomorrowAsDate', () => {
-    it("should return tomorrow's date as Date object", () => {
-        const server_time = '2025-04-08 09:28:52';
-        const result = DateTime.getTomorrowAsDate(server_time);
-
-        expect(result).toBeInstanceOf(Date);
-        expect(result.getFullYear()).toBe(2025);
-        expect(result.getMonth()).toBe(3); // April is 3 (0-based)
-        expect(result.getDate()).toBe(9);
-    });
-
-    it('should handle different input formats', () => {
-        const date_object = new Date('2025-04-08T09:28:52');
-        const result = DateTime.getTomorrowAsDate(date_object);
-
-        expect(result).toBeInstanceOf(Date);
-        expect(result.getFullYear()).toBe(2025);
-        expect(result.getMonth()).toBe(3);
-        expect(result.getDate()).toBe(9);
-    });
-
-    it('should handle month rollover', () => {
-        const server_time = '2025-04-30 09:28:52';
-        const result = DateTime.getTomorrowAsDate(server_time);
-
-        expect(result).toBeInstanceOf(Date);
-        expect(result.getFullYear()).toBe(2025);
-        expect(result.getMonth()).toBe(4); // May is 4 (0-based)
-        expect(result.getDate()).toBe(1);
-    });
-});

--- a/packages/shared/src/utils/date/date-time.ts
+++ b/packages/shared/src/utils/date/date-time.ts
@@ -312,3 +312,21 @@ export const getTimeSince = (timestamp: number) => {
     }
     return localize('{{days_passed}}d ago', { days_passed: Math.floor(seconds_passed / (3600 * 24)) });
 };
+
+/**
+ * Get tomorrow's date in YYYY-MM-DD format
+ * @param {moment.MomentInput} server_time - Server time to calculate tomorrow from
+ * @return {string} Tomorrow's date in YYYY-MM-DD format
+ */
+export const getTomorrowDate = (server_time: moment.MomentInput): string => {
+    return toMoment(server_time).clone().add(1, 'day').format('YYYY-MM-DD');
+};
+
+/**
+ * Get tomorrow's date as Date object
+ * @param {moment.MomentInput} server_time - Server time to calculate tomorrow from
+ * @return {Date} Tomorrow's date as Date object
+ */
+export const getTomorrowAsDate = (server_time: moment.MomentInput): Date => {
+    return toMoment(server_time).clone().add(1, 'day').toDate();
+};

--- a/packages/shared/src/utils/date/date-time.ts
+++ b/packages/shared/src/utils/date/date-time.ts
@@ -321,12 +321,3 @@ export const getTimeSince = (timestamp: number) => {
 export const getTomorrowDate = (server_time: moment.MomentInput): string => {
     return toMoment(server_time).clone().add(1, 'day').format('YYYY-MM-DD');
 };
-
-/**
- * Get tomorrow's date as Date object
- * @param {moment.MomentInput} server_time - Server time to calculate tomorrow from
- * @return {Date} Tomorrow's date as Date object
- */
-export const getTomorrowAsDate = (server_time: moment.MomentInput): Date => {
-    return toMoment(server_time).clone().add(1, 'day').toDate();
-};

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
@@ -7,7 +7,7 @@ import DaysDatepicker from './datepicker';
 import EndTimePicker from './timepicker';
 import { useStore } from '@deriv/stores';
 import { useTraderStore } from 'Stores/useTraderStores';
-import { hasIntradayDurationUnit, setTime, toMoment } from '@deriv/shared';
+import { getTomorrowAsDate, hasIntradayDurationUnit, setTime, toMoment } from '@deriv/shared';
 import { getBoundaries } from 'Stores/Modules/Trading/Helpers/end-time';
 import {
     getClosestTimeToCurrentGMT,
@@ -231,6 +231,11 @@ const DayInput = ({
         }
         setTriggerDate(true);
     };
+
+    React.useEffect(() => {
+        handleDate(getTomorrowAsDate(server_time));
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     return (
         <div className='duration-container__days-input'>

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/day.tsx
@@ -7,7 +7,7 @@ import DaysDatepicker from './datepicker';
 import EndTimePicker from './timepicker';
 import { useStore } from '@deriv/stores';
 import { useTraderStore } from 'Stores/useTraderStores';
-import { getTomorrowAsDate, hasIntradayDurationUnit, setTime, toMoment } from '@deriv/shared';
+import { hasIntradayDurationUnit, setTime, toMoment } from '@deriv/shared';
 import { getBoundaries } from 'Stores/Modules/Trading/Helpers/end-time';
 import {
     getClosestTimeToCurrentGMT,
@@ -231,11 +231,6 @@ const DayInput = ({
         }
         setTriggerDate(true);
     };
-
-    React.useEffect(() => {
-        handleDate(getTomorrowAsDate(server_time));
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
 
     return (
         <div className='duration-container__days-input'>

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
@@ -55,7 +55,21 @@ const Duration = observer(({ is_minimized }: TTradeParametersProps) => {
     const { server_time } = common;
 
     useEffect(() => {
-        if (expiry_epoch) {
+        if (expiry_epoch && duration_unit !== 'd') {
+            // Set expiry time to end of day
+            setExpiryTimeString('23:59:59');
+
+            // Get tomorrow's date
+            const today = new Date();
+            const tomorrow = new Date(today);
+            tomorrow.setDate(today.getDate() + 1);
+            tomorrow.setHours(23, 59, 59, 0);
+            const tomorrow_date = tomorrow.toISOString().split('T')[0];
+
+            setExpiryDateString(tomorrow_date);
+            setSavedExpiryDateV2(tomorrow_date);
+        }
+        if (expiry_epoch && duration_unit === 'd' && !expiry_time_string) {
             setExpiryTimeString(
                 new Date((expiry_epoch as number) * 1000).toISOString().split('T')[1].substring(0, 8) || ''
             );

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 import { observer } from 'mobx-react-lite';
 import { ActionSheet, TextField, useSnackbar } from '@deriv-com/quill-ui';
-import { getUnitMap } from '@deriv/shared';
+import { getTomorrowDate, getUnitMap, toMoment } from '@deriv/shared';
 import { Localize, localize } from '@deriv/translations';
 import { useTraderStore } from 'Stores/useTraderStores';
 import DurationActionSheetContainer from './container';
@@ -60,12 +60,7 @@ const Duration = observer(({ is_minimized }: TTradeParametersProps) => {
             setExpiryTimeString('23:59:59');
 
             // Get tomorrow's date
-            const today = new Date();
-            const tomorrow = new Date(today);
-            tomorrow.setDate(today.getDate() + 1);
-            tomorrow.setHours(23, 59, 59, 0);
-            const tomorrow_date = tomorrow.toISOString().split('T')[0];
-
+            const tomorrow_date = getTomorrowDate(server_time);
             setExpiryDateString(tomorrow_date);
             setSavedExpiryDateV2(tomorrow_date);
         }

--- a/packages/trader/src/Modules/Trading/Components/Form/DatePicker/trading-date-picker.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/DatePicker/trading-date-picker.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import moment from 'moment';
 import React from 'react';
 import { DatePicker, Tooltip } from '@deriv/components';
-import { isTimeValid, setTime, toMoment, useIsMounted, hasIntradayDurationUnit } from '@deriv/shared';
+import { isTimeValid, setTime, toMoment, useIsMounted, hasIntradayDurationUnit, getTomorrowDate } from '@deriv/shared';
 import { localize } from '@deriv/translations';
 import { ContractType } from 'Stores/Modules/Trading/Helpers/contract-type';
 import { observer, useStore } from '@deriv/stores';
@@ -37,10 +37,16 @@ const TradingDatePicker = observer(({ id, is_24_hours_contract, mode, name }: TT
 
     const isMounted = useIsMounted();
 
+    const hasRangeSelection = () => mode === 'duration';
+
     const [disabled_days, setDisabledDays] = React.useState<number[]>([]);
     const [market_events, setMarketEvents] = React.useState<TMarketEvent[]>([]);
     const [duration, setDuration] = React.useState(current_duration);
-    const [selected_date, setSelectedDate] = React.useState<moment.Moment>();
+    const [selected_date, setSelectedDate] = React.useState<moment.Moment | undefined>(() => {
+        if (!hasRangeSelection() && expiry_type === 'endtime') {
+            return toMoment(getTomorrowDate(server_time));
+        }
+    });
 
     React.useEffect(() => {
         onChangeCalendarMonth();
@@ -84,8 +90,6 @@ const TradingDatePicker = observer(({ id, is_24_hours_contract, mode, name }: TT
             ? getMomentContractStartDateTime().clone().add(max_daily_duration, 'second')
             : getMomentContractStartDateTime().clone().add(getMaxDailyDuration(), 'second');
     };
-
-    const hasRangeSelection = () => mode === 'duration';
 
     const getFooter = () => {
         if (!hasRangeSelection()) return '';

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/advanced-duration.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/advanced-duration.tsx
@@ -71,8 +71,7 @@ const AdvancedDuration = observer(
     }: TAdvancedDuration) => {
         const { ui } = useStore();
         const { current_focus, setCurrentFocus } = ui;
-        const { contract_expiry_type, duration_min_max, validation_errors, onChangeMultiple, contract_type } =
-            useTraderStore();
+        const { contract_expiry_type, duration_min_max, validation_errors, onChangeMultiple } = useTraderStore();
         const [min, max] = getDurationMinMaxValues(duration_min_max, contract_expiry_type, advanced_duration_unit);
         let is_24_hours_contract = false;
 

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/advanced-duration.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/advanced-duration.tsx
@@ -71,8 +71,8 @@ const AdvancedDuration = observer(
     }: TAdvancedDuration) => {
         const { ui } = useStore();
         const { current_focus, setCurrentFocus } = ui;
-        const { contract_expiry_type, duration_min_max, validation_errors, onChangeMultiple } = useTraderStore();
-
+        const { contract_expiry_type, duration_min_max, validation_errors, onChangeMultiple, contract_type } =
+            useTraderStore();
         const [min, max] = getDurationMinMaxValues(duration_min_max, contract_expiry_type, advanced_duration_unit);
         let is_24_hours_contract = false;
 
@@ -108,13 +108,12 @@ const AdvancedDuration = observer(
         const { name_plural, name } = getUnitMap()[advanced_duration_unit];
         const duration_unit_text = name_plural ?? name;
 
-        React.useEffect(() => {
+        React.useLayoutEffect(() => {
             if (expiry_type === 'endtime') {
-                // Set expiry date to tomorrow when switching to end time
-                onChange({ target: { name: 'expiry_date', value: getTomorrowDate(server_time) } });
+                setTimeout(() => onChange({ target: { name: 'expiry_date', value: getTomorrowDate(server_time) } }));
             }
             // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, []);
+        }, [contract_type, expiry_type]);
 
         return (
             <>

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/advanced-duration.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Duration/advanced-duration.tsx
@@ -108,12 +108,15 @@ const AdvancedDuration = observer(
         const { name_plural, name } = getUnitMap()[advanced_duration_unit];
         const duration_unit_text = name_plural ?? name;
 
-        React.useLayoutEffect(() => {
+        React.useEffect(() => {
             if (expiry_type === 'endtime') {
-                setTimeout(() => onChange({ target: { name: 'expiry_date', value: getTomorrowDate(server_time) } }));
+                setTimeout(
+                    () => onChange({ target: { name: 'expiry_date', value: getTomorrowDate(server_time) } }),
+                    100
+                );
             }
             // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, [contract_type, expiry_type]);
+        }, [expiry_type]);
 
         return (
             <>


### PR DESCRIPTION
## Changes:

- Added a default value for end date equal to tomorrow (current date + 1 day) for both desktop + mobile
- Created helper function
- Expanded test cases

Recommend to refactor mobile duration component

### Screenshots:

https://github.com/user-attachments/assets/ec9b558c-d940-4628-a3e1-172976ddc4ee


https://github.com/user-attachments/assets/bc7919e7-2be2-4c86-a038-e375e773a501

