### PR TITLE
Aizad/86c2v38kk/2 banners is shown in Trader's hub home if client is eligible for migration.

### DIFF
--- a/packages/appstore/src/components/banners/traders-hub-banners/traders-hub-banners.tsx
+++ b/packages/appstore/src/components/banners/traders-hub-banners/traders-hub-banners.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+
 import { Loading } from '@deriv/components';
-import { useStore, observer } from '@deriv/stores';
+import { useGrowthbookGetFeatureValue, useStoreHasAccountDeposited } from '@deriv/hooks';
 import { makeLazyLoader, moduleLoader } from '@deriv/shared';
-import { useContentFlag, useGrowthbookGetFeatureValue, useStoreHasAccountDeposited } from '@deriv/hooks';
+import { observer, useStore } from '@deriv/stores';
+
 import BookBanner from 'Components/banners/book-banner';
 import WalletsBanner from 'Components/banners/wallets-banner';
 
@@ -63,7 +65,7 @@ const TradersHubBanners = observer(() => {
             {should_show_real_account_creation_banner && <RealAccountCreationBanner />}
             {should_show_deposit_now_banner && <DepositNowBanner />}
             <BookBanner />
-            <WalletsBanner />
+            {!should_show_deposit_now_banner && <WalletsBanner />}
         </React.Fragment>
     );
 });


### PR DESCRIPTION
## Changes:
- Added new condition to show `<WalletsBanner>`
- Remove unused imports
- Reformat import order

### Screenshots:
**Before**
![image](https://github.com/user-attachments/assets/8816f90d-2770-470c-965e-abe5accd03d4)
**After**
![image](https://github.com/user-attachments/assets/45832e28-8988-46e6-be73-64df2be665ef)


