### PR TITLE
GRWT-5444 / Kate / Overwrite chip style

### DIFF
--- a/packages/trader/src/AppV2/Containers/Trade/trade.scss
+++ b/packages/trader/src/AppV2/Containers/Trade/trade.scss
@@ -25,7 +25,11 @@
         }
 
         button {
-            background-color: transparent;
+            background-color: transparent !important;
+
+            &.quill-chip[data-state='selected'] {
+                background-color: var(--component-chip-bg-selected) !important;
+            }
         }
 
         &-header {


### PR DESCRIPTION
## Changes:

The task was removed all background colors from chip with trade types except white&black in order not to confuse users with light-grey chip highlight on hover/active. Because original styles coming from quill I was forced to use !important

### Screenshots:

https://github.com/user-attachments/assets/751cd2c0-a1f9-4cfe-83c8-e85a9870c028

