### PR TITLE
Aum / TRAH-6000 / Fix cashier transfer field

### DIFF
--- a/packages/cashier/src/pages/account-transfer/account-transfer-form/account-transfer-form.scss
+++ b/packages/cashier/src/pages/account-transfer/account-transfer-form/account-transfer-form.scss
@@ -151,7 +151,7 @@
             min-width: 36rem;
             height: 6.5rem;
             margin-bottom: 0;
-            text-align: left;
+            text-align: start;
 
             .dc-input__hint {
                 margin: 0.5rem 0 -1.9rem 1.3rem;


### PR DESCRIPTION
## Changes:

Issue: Input amount was overlapping the currency (icon prop of input field) due to overridden text align.
Fix: Change text-align from "left" to "start" which automatically switches input alignment based on RTL of browser.

### Screenshots:

https://github.com/user-attachments/assets/a5d4366a-9575-428b-a0a1-2969892648e1
