### PR TITLE
Nijil / TRAH-5968 / Min transfer limit message on user input

### DIFF
--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/useTransferMessages.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/useTransferMessages.tsx
@@ -9,6 +9,7 @@ import {
     cumulativeAccountLimitsMessageFn,
     insufficientBalanceMessageFn,
     lifetimeAccountLimitsBetweenWalletsMessageFn,
+    minimumTransferLimitMessageFn,
     tradingPlatformStatusMessageFn,
     transferFeesBetweenWalletsMessageFn,
 } from './utils';
@@ -65,6 +66,7 @@ const useTransferMessages = ({
 
         // messageFns.push(validateNumber);
 
+        messageFns.push(minimumTransferLimitMessageFn);
         messageFns.push(insufficientBalanceMessageFn);
         messageFns.push(countLimitMessageFn);
 

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/index.ts
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/index.ts
@@ -2,6 +2,7 @@ import countLimitMessageFn from './countLimitsMessageFn';
 import cumulativeAccountLimitsMessageFn from './cumulativeAccountLimitsMessageFn';
 import insufficientBalanceMessageFn from './insufficientBalanceMessageFn';
 import lifetimeAccountLimitsBetweenWalletsMessageFn from './lifetimeAccountLimitsBetweenWalletsMessageFn';
+import minimumTransferLimitMessageFn from './minimumTransferLimitMessageFn';
 import tradingPlatformStatusMessageFn from './tradingPlatformStatusMessageFn';
 import transferFeesBetweenWalletsMessageFn from './transferFeesBetweenWalletsMessageFn';
 
@@ -10,6 +11,7 @@ export {
     cumulativeAccountLimitsMessageFn,
     insufficientBalanceMessageFn,
     lifetimeAccountLimitsBetweenWalletsMessageFn,
+    minimumTransferLimitMessageFn,
     tradingPlatformStatusMessageFn,
     transferFeesBetweenWalletsMessageFn,
 };

--- a/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/minimumTransferLimitMessageFn.tsx
+++ b/packages/wallets/src/features/cashier/modules/Transfer/hooks/useTransferMessages/utils/minimumTransferLimitMessageFn.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Localize } from '@deriv-com/translations';
+import { TMessageFnProps } from '../../../types';
+
+const minimumTransferLimitMessageFn = ({
+    displayMoney,
+    sourceAccount,
+    sourceAmount,
+    targetAccount,
+}: TMessageFnProps) => {
+    if (!sourceAccount || !targetAccount || !sourceAmount) return null;
+
+    // Determine the account type for limit selection
+    const isCtraderTransfer = [sourceAccount, targetAccount].some(acc => acc.account_type === 'ctrader');
+    const isMT5Transfer = [sourceAccount, targetAccount].some(acc => acc.account_type === 'mt5');
+    const isDxtradeTransfer = [sourceAccount, targetAccount].some(acc => acc.account_type === 'dxtrade');
+
+    // Get the appropriate minimum limit based on account types
+    let minLimit;
+    if (isCtraderTransfer) {
+        minLimit = sourceAccount.currencyConfig?.transfer_between_accounts?.limits_ctrader?.min;
+    } else if (isMT5Transfer) {
+        minLimit = sourceAccount.currencyConfig?.transfer_between_accounts?.limits_mt5?.min;
+    } else if (isDxtradeTransfer) {
+        minLimit = sourceAccount.currencyConfig?.transfer_between_accounts?.limits_dxtrade?.min;
+    } else {
+        minLimit = sourceAccount.currencyConfig?.transfer_between_accounts?.limits?.min;
+    }
+
+    // If min limit is not available or amount is greater than or equal to min limit, return null
+    if (!minLimit || typeof minLimit !== 'number' || sourceAmount >= minLimit) return null;
+
+    // Format the minimum limit for display
+    const formattedMinLimit = displayMoney?.(
+        minLimit,
+        sourceAccount.currency || '',
+        sourceAccount.currencyConfig?.fractional_digits || 2
+    );
+
+    // Create a single message format for all transfer types
+    const message = (
+        <Localize
+            i18n_default_text='Minimum required amount is {{formattedMinLimit}}'
+            values={{
+                formattedMinLimit,
+            }}
+        />
+    );
+
+    return {
+        message,
+        type: 'error' as const,
+    };
+};
+
+export default minimumTransferLimitMessageFn;


### PR DESCRIPTION
## Changes:

Issue: The minimum transfer message does not appear when the user enters the amount for transfer. The message only appears after clicking the transfer button and receiving an error.

Expected Behavior: The minimum transfer message should appear as soon as the user enters an amount below the minimum transfer limit, not only after clicking the transfer button.

### Screenshots:

<img width="1278" alt="Screenshot 2025-04-10 at 11 47 48 AM" src="https://github.com/user-attachments/assets/bfc33b9e-0598-477d-a09d-ffa72b8ee13c" />
