### PR TITLE
Suisin/chore: replace window state before redirecting because safari issue

### DIFF
--- a/packages/core/src/Modules/Callback/CallbackPage.tsx
+++ b/packages/core/src/Modules/Callback/CallbackPage.tsx
@@ -75,8 +75,10 @@ const CallbackPage = () => {
                 } else {
                     const postLoginRedirectUri = localStorage.getItem('config.post_login_redirect_uri');
                     if (postLoginRedirectUri) {
+                        window.history.replaceState({}, '', postLoginRedirectUri);
                         window.location.href = postLoginRedirectUri;
                     } else {
+                        window.history.replaceState({}, '', routes.traders_hub);
                         window.location.href = routes.traders_hub;
                     }
                 }


### PR DESCRIPTION
## Changes:

Replace state before redirecting to the page, so that the browser will not redirect back to the callback page

### Screenshots:

https://github.com/user-attachments/assets/049f517b-722f-4d87-b534-649bf98457e9



