### PR TITLE
GRWT-5624 / Kate / Removed disabled account from account switcher

### DIFF
--- a/packages/core/src/Constants/currency.js
+++ b/packages/core/src/Constants/currency.js
@@ -1,0 +1,3 @@
+export const CURRENCY_CONSTANTS = {
+    UST: 'UST',
+};

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -680,9 +680,11 @@ export default class ClientStore extends BaseStore {
             );
         return landing_company ? this.landing_companies[landing_company] : undefined;
     }
-
+    // Hiding UST account from the Authorization call, as it should be not just disabled, but temporary removed
     get account_list() {
-        return this.all_loginids.map(id => this.getAccountInfo(id)).filter(account => account);
+        return this.all_loginids
+            .map(id => this.getAccountInfo(id))
+            .filter(account => !(account.title === 'UST' && account.is_disabled));
     }
 
     get has_real_mt5_login() {

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -46,6 +46,7 @@ import BaseStore from './base-store';
 import BinarySocket from '_common/base/socket_base';
 import * as SocketCache from '_common/base/socket_cache';
 import { getRegion, isEuCountry, isMultipliersOnly, isOptionsBlocked } from '_common/utility';
+import { CURRENCY_CONSTANTS } from '../Constants/currency';
 
 const LANGUAGE_KEY = 'i18n_language';
 const storage_key = 'client.accounts';
@@ -684,7 +685,7 @@ export default class ClientStore extends BaseStore {
     get account_list() {
         return this.all_loginids
             .map(id => this.getAccountInfo(id))
-            .filter(account => !(account.title === 'UST' && account.is_disabled));
+            .filter(account => !(account.title === CURRENCY_CONSTANTS.UST && account.is_disabled));
     }
 
     get has_real_mt5_login() {


### PR DESCRIPTION
## Changes:

The Thether Omni USDT is still coming in Authorize call, but with disabled flag. As I want to preserve the logic for disabling accounts, I added a filtration to exclude 'UST' if it's disabled with a comment. Haven't removed icon in case if it will be enabled in future.
Account will be removed from DTrader and DBot.
In SmartTrader (production) account is not visible, hence haven't change it.

### Screenshots:

<img width="1320" alt="Screenshot 2025-04-14 at 10 50 26 AM" src="https://github.com/user-attachments/assets/78f7b27c-556b-4543-b1ff-bbee89c5c226" />
<img width="1320" alt="Screenshot 2025-04-14 at 10 50 58 AM" src="https://github.com/user-attachments/assets/93ea8dfa-a369-414d-b4c9-b08efff57af2" />

