### PR TITLE
GRWT-5645 / Kate / Remove Quill component rounding issues

### DIFF
--- a/packages/trader/src/AppV2/Components/RiskManagementItem/risk-management-item.tsx
+++ b/packages/trader/src/AppV2/Components/RiskManagementItem/risk-management-item.tsx
@@ -212,7 +212,6 @@ const RiskManagementItem = observer(
                                     placeholder={localize('Amount')}
                                     regex={/[^0-9.,]/g}
                                     status={error_message ? 'error' : 'neutral'}
-                                    shouldRound={false}
                                     textAlignment='center'
                                     inputMode='decimal'
                                     unitLeft={getCurrencyDisplayCode(currency)}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier-input.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier-input.tsx
@@ -229,7 +229,6 @@ const BarrierInput = observer(
                                     inputMode='decimal'
                                     allowSign={false}
                                     status={show_hidden_error ? 'error' : 'neutral'}
-                                    // shouldRound={false}
                                     onChange={handleOnChange}
                                     placeholder={localize('Distance to spot')}
                                     regex={/[^0-9.,]/g}

--- a/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier-input.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier-input.tsx
@@ -203,7 +203,6 @@ const BarrierInput = observer(
                                     name='barrier_1'
                                     noStatusIcon
                                     status={show_hidden_error ? 'error' : 'neutral'}
-                                    shouldRound={false}
                                     value={barrier_1}
                                     allowDecimals
                                     decimals={pip_size}
@@ -230,7 +229,7 @@ const BarrierInput = observer(
                                     inputMode='decimal'
                                     allowSign={false}
                                     status={show_hidden_error ? 'error' : 'neutral'}
-                                    shouldRound={false}
+                                    // shouldRound={false}
                                     onChange={handleOnChange}
                                     placeholder={localize('Distance to spot')}
                                     regex={/[^0-9.,]/g}

--- a/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/take-profit-and-stop-loss-input.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/take-profit-and-stop-loss-input.tsx
@@ -279,7 +279,6 @@ const TakeProfitAndStopLossInput = ({
                     ref={input_ref}
                     regex={/[^0-9.,]/g}
                     status={fe_error_text || error_text ? 'error' : 'neutral'}
-                    shouldRound={false}
                     textAlignment='center'
                     unitLeft={currency_display_code}
                     variant='fill'

--- a/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake-input.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake-input.tsx
@@ -407,7 +407,6 @@ const StakeInput = observer(({ onClose, is_open }: TStakeInput) => {
                     placeholder={localize('Amount')}
                     regex={/[^0-9.,]/g}
                     status={fe_stake_error || (should_show_stake_error && stake_error) ? 'error' : 'neutral'}
-                    shouldRound={false}
                     textAlignment='center'
                     unitLeft={getCurrencyDisplayCode(currency)}
                     value={proposal_request_values.amount}


### PR DESCRIPTION
## Changes:

The issue happens not only in barrier input, but in other Quill inputs too (Stake, Take profit, Stop Loss). The issue is in prop 'shouldRound' that we are passing to text input.

When value ends with '00', Quill rounds it and cut all numbers, except two first.

E.g. 300,00 -> 30
127675,00 -> 12

Ideally, fix should be applied to Quill repository, but because of the hight priority of the card, the fact that we don't actually need rounding in mobile (as we are not using it in desktop, stick to consistency) and taht design team is building new quill components, we can fix it on our side (deriv-app). Now, if value ends with '00' we are not rounding/cutting it. Instead we are handling it the same way as in desktop (consistency) and allowing user to enter it. Fixed was applied to Barrier, Stake, Take profit and Stop Loss.

### Screenshots:


https://github.com/user-attachments/assets/185bdfaa-b327-48dc-9e68-b2b84ab28853


