### PR TITLE
GRWT-5621 / Kate / Rename trade type category

### DIFF
--- a/packages/shared/src/utils/constants/__tests__/contract.spec.ts
+++ b/packages/shared/src/utils/constants/__tests__/contract.spec.ts
@@ -249,8 +249,8 @@ describe('getContractCategoriesConfig', () => {
                     TRADE_TYPES.CALL_PUT_SPREAD,
                 ],
             },
-            'Highs & Lows': {
-                name: 'Highs & Lows',
+            'Touch & No Touch': {
+                name: 'Touch & No Touch',
                 categories: [TRADE_TYPES.TOUCH, TRADE_TYPES.TICK_HIGH_LOW],
             },
             'Ins & Outs': { name: 'Ins & Outs', categories: [TRADE_TYPES.END, TRADE_TYPES.STAY] },

--- a/packages/shared/src/utils/constants/contract.ts
+++ b/packages/shared/src/utils/constants/contract.ts
@@ -230,8 +230,8 @@ export const getContractCategoriesConfig = () =>
                 TRADE_TYPES.CALL_PUT_SPREAD,
             ],
         },
-        'Highs & Lows': {
-            name: localize('Highs & Lows'),
+        'Touch & No Touch': {
+            name: localize('Touch & No Touch'),
             categories: [TRADE_TYPES.TOUCH, TRADE_TYPES.TICK_HIGH_LOW],
         },
         'Ins & Outs': { name: localize('Ins & Outs'), categories: [TRADE_TYPES.END, TRADE_TYPES.STAY] },

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/__tests__/contract-type-display.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/__tests__/contract-type-display.spec.tsx
@@ -54,7 +54,7 @@ const list = [
             },
         ],
         icon: 'IcHighsLows',
-        label: 'Highs & Lows',
+        label: 'Touch & No Touch',
         key: 'Options',
     },
     {

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/__tests__/contract-type-info.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/__tests__/contract-type-info.spec.tsx
@@ -68,8 +68,8 @@ const mocked_props: React.ComponentProps<typeof Info> = {
                         },
                     ],
                     icon: 'IcHighsLows',
-                    label: 'Highs & Lows',
-                    key: 'Highs & Lows',
+                    label: 'Touch & No Touch',
+                    key: 'Touch & No Touch',
                 },
                 {
                     contract_types: [
@@ -197,8 +197,8 @@ const mocked_props: React.ComponentProps<typeof Info> = {
                         },
                     ],
                     icon: 'IcHighsLows',
-                    label: 'Highs & Lows',
-                    key: 'Highs & Lows',
+                    label: 'Touch & No Touch',
+                    key: 'Touch & No Touch',
                 },
                 {
                     contract_types: [
@@ -302,11 +302,11 @@ describe('<Info />', () => {
 
         expect(screen.queryByText(choose_multipliers)).toBeInTheDocument();
     });
-    it('Should call handleSelect when clicking on "Choose Multipliers" button', () => {
+    it('Should call handleSelect when clicking on "Choose Multipliers" button', async () => {
         render(mockInfoProvider());
 
         const trade_type_button = screen.queryByText(choose_multipliers) as HTMLButtonElement;
-        userEvent.click(trade_type_button);
+        await userEvent.click(trade_type_button);
 
         expect(trade_type_button).toBeInTheDocument();
         expect(mocked_props.handleSelect).toHaveBeenCalled();

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/__tests__/contract-type-menu.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/__tests__/contract-type-menu.spec.tsx
@@ -78,8 +78,8 @@ describe('ContractTypeMenu', () => {
                         },
                     ],
                     icon: 'IcHighsLows',
-                    label: 'Highs & Lows',
-                    key: 'Highs & Lows',
+                    label: 'Touch & No Touch',
+                    key: 'Touch & No Touch',
                 },
                 {
                     contract_types: [
@@ -192,8 +192,8 @@ describe('ContractTypeMenu', () => {
                         },
                     ],
                     icon: 'IcHighsLows',
-                    label: 'Highs & Lows',
-                    key: 'Highs & Lows',
+                    label: 'Touch & No Touch',
+                    key: 'Touch & No Touch',
                 },
                 {
                     contract_types: [
@@ -290,8 +290,8 @@ describe('ContractTypeMenu', () => {
                 },
             ],
             icon: 'IcHighsLows',
-            label: 'Highs & Lows',
-            key: 'Highs & Lows',
+            label: 'Touch & No Touch',
+            key: 'Touch & No Touch',
         },
         {
             contract_types: [

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/__tests__/contract-type-widget.spec.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/__tests__/contract-type-widget.spec.tsx
@@ -55,7 +55,7 @@ describe('<ContractTypeWidget />', () => {
                 },
             ],
             icon: 'IcHighsLows',
-            label: 'Highs & Lows',
+            label: 'Touch & No Touch',
             key: 'Options',
         },
         {

--- a/packages/trader/src/Modules/Trading/Helpers/contract-type.tsx
+++ b/packages/trader/src/Modules/Trading/Helpers/contract-type.tsx
@@ -20,7 +20,7 @@ export const isMajorPairsSymbol = (checked_symbol: string, active_symbols: Activ
 
 export const contract_category_icon = {
     [localize('Ups & Downs')]: 'IcUpsDowns',
-    [localize('Highs & Lows')]: 'IcHighsLows',
+    [localize('Touch & No Touch')]: 'IcHighsLows',
     [localize('Ins & Outs')]: 'IcInsOuts',
     [localize('Look Backs')]: 'IcLookbacks',
     [localize('Digits')]: 'IcDigits',
@@ -34,7 +34,7 @@ export const ordered_trade_categories = [
     'Turbos',
     'Multipliers',
     'Ups & Downs',
-    'Highs & Lows',
+    'Touch & No Touch',
     'Digits',
 ];
 
@@ -45,7 +45,7 @@ export const getContractTypeCategoryIcons = () =>
         Options: 'IcCatOptions',
         Multipliers: 'IcCatMultiplier',
         Turbos: 'IcCatTurbos',
-    } as const);
+    }) as const;
 
 /**
  * Returns a list of contracts in the following format:
@@ -69,7 +69,7 @@ export const getAvailableContractTypes = (
             const available_contract_types = contract_types.filter(type =>
                 type.value &&
                 // TODO: remove this check once all contract types are supported
-                !unsupported_list.includes(type.value as typeof unsupported_contract_types_list[number])
+                !unsupported_list.includes(type.value as (typeof unsupported_contract_types_list)[number])
                     ? type
                     : undefined
             );

--- a/packages/trader/src/Stores/Modules/Trading/Helpers/__tests__/contract-type.spec.ts
+++ b/packages/trader/src/Stores/Modules/Trading/Helpers/__tests__/contract-type.spec.ts
@@ -242,8 +242,8 @@ describe('ContractType.getContractType', () => {
                     },
                 ],
             },
-            'Highs & Lows': {
-                name: 'Highs & Lows',
+            'Touch & No Touch': {
+                name: 'Touch & No Touch',
                 categories: [
                     {
                         value: 'high_low',


### PR DESCRIPTION
## Changes:

Renamed "Highs & Lows" category  ---> "Touch & No Touch".
Changed paddings as per Figma.


### Screenshots:

<img width="1368" alt="Screenshot 2025-04-17 at 12 22 34 PM" src="https://github.com/user-attachments/assets/7f4bb714-c904-40de-8eb2-98f79c59948e" />
