### PR TITLE
Lubega / TRAH-6172 / Ctrader account transfer redirect

### DIFF
--- a/packages/core/src/App/Containers/Redirect/redirect.jsx
+++ b/packages/core/src/App/Containers/Redirect/redirect.jsx
@@ -3,7 +3,8 @@ import { useHistory, withRouter } from 'react-router-dom';
 import Cookies from 'js-cookie';
 import PropTypes from 'prop-types';
 
-import { getDomainName, loginUrl, redirectToLogin, routes, SessionStore } from '@deriv/shared';
+import { useIsHubRedirectionEnabled } from '@deriv/hooks';
+import { getDomainName, loginUrl, platforms, redirectToLogin, routes, SessionStore } from '@deriv/shared';
 import { observer, useStore } from '@deriv/stores';
 import { getLanguage } from '@deriv/translations';
 import { Chat } from '@deriv/utils';
@@ -42,6 +43,8 @@ const Redirect = observer(() => {
         toggleUpdateEmailModal,
         is_mobile,
     } = ui;
+
+    const { isHubRedirectionEnabled } = useIsHubRedirectionEnabled();
 
     const url_query_string = window.location.search;
     const url_params = new URLSearchParams(url_query_string);
@@ -319,6 +322,17 @@ const Redirect = observer(() => {
                 pathname: routes.cashier_p2p,
                 search: url_query_string,
             });
+            redirected_to_route = true;
+            break;
+        }
+        case 'ctrader_account_transfer': {
+            if (isHubRedirectionEnabled && has_wallet) {
+                window.location.assign(`${platforms.tradershub_os.url}/wallets/transfer`);
+            } else if (has_wallet) {
+                history.push(routes.wallets_transfer);
+            } else {
+                history.push(routes.cashier_acc_transfer);
+            }
             redirected_to_route = true;
             break;
         }

--- a/packages/shared/src/utils/config/platform-config.ts
+++ b/packages/shared/src/utils/config/platform-config.ts
@@ -15,8 +15,8 @@ type TPlatform = {
 type TPlatforms = Record<'p2p' | 'p2p_v2' | 'derivgo' | 'tradershub_os', TPlatform>;
 export const tradershub_os_url =
     process.env.NODE_ENV === 'production'
-        ? 'https://hub.deriv.com/tradershub/cfds'
-        : 'https://staging-hub.deriv.com/tradershub/cfds';
+        ? 'https://hub.deriv.com/tradershub'
+        : 'https://staging-hub.deriv.com/tradershub';
 
 // TODO: This should be moved to PlatformContext
 export const platforms: TPlatforms = {


### PR DESCRIPTION
## Changes:

- [x] Added conditional redirect to low code wallets, high code wallets or legacy transfer depending on the account
- [x] Current ctrader web terminal url is hardcoded to the legacy transfer url. This will be updated from the webflow side to: `https://app.deriv.com/redirect?action=ctrader_account_transfer`
