### PR TITLE
Moiz-GRWT-5559-[DTrader] Implement P/L of all positions in Recent Positions drawer

### DIFF
--- a/packages/trader/src/App/Components/Elements/PositionsDrawer/__tests__/positions-drawer.spec.tsx
+++ b/packages/trader/src/App/Components/Elements/PositionsDrawer/__tests__/positions-drawer.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mockStore, useStore } from '@deriv/stores';
 import { TCoreStores } from '@deriv/stores/types';
-import { mockContractInfo, CONTRACT_TYPES, TRADE_TYPES } from '@deriv/shared';
+import { mockContractInfo, CONTRACT_TYPES, TRADE_TYPES, isEmptyObject } from '@deriv/shared';
 import PositionsDrawer from '../positions-drawer';
 import TraderProviders from '../../../../../trader-providers';
 
@@ -16,10 +16,11 @@ const mocked_store = {
         },
     },
     portfolio: { all_positions: [] as TAllPositions, error: '', onHoverPosition: jest.fn() },
+    client: { currency: 'USD' },
 };
 const empty_portfolio_message = 'EmptyPortfolioMessage';
 const position_drawer_card = 'PositionsDrawerCard';
-const recent_positions = 'Recent positions';
+const open_positions = 'Open positions';
 const go_to_reports = 'Go to Reports';
 
 jest.mock('react-router-dom', () => ({
@@ -44,6 +45,12 @@ jest.mock('@deriv/components', () => ({
 jest.mock('../../EmptyPortfolioMessage', () => jest.fn(() => <div>{empty_portfolio_message}</div>));
 
 describe('<PositionsDrawer />', () => {
+    beforeEach(() => {
+        mocked_store.portfolio.all_positions = [];
+        mocked_store.portfolio.error = '';
+        mocked_store.client.currency = 'USD';
+    });
+
     const mockPositionsDrawer = (mocked_store: TCoreStores) => {
         return (
             <TraderProviders store={mocked_store}>
@@ -55,9 +62,8 @@ describe('<PositionsDrawer />', () => {
     it('should render Recent positions with empty portfolio message if there is no open positions', () => {
         render(mockPositionsDrawer(mockStore(mocked_store)));
 
-        expect(screen.getByText(recent_positions)).toBeInTheDocument();
+        expect(screen.getByText(open_positions)).toBeInTheDocument();
         expect(screen.getByText(empty_portfolio_message)).toBeInTheDocument();
-        expect(screen.getByText(go_to_reports)).toBeInTheDocument();
     });
 
     it('should render Recent positions with empty portfolio message if there is opened forward starting contract, which has not started yet (current_spot_time is less or equal to date_start)', () => {
@@ -71,9 +77,8 @@ describe('<PositionsDrawer />', () => {
             },
         ] as TAllPositions;
 
-        expect(screen.getByText(recent_positions)).toBeInTheDocument();
+        expect(screen.getByText(open_positions)).toBeInTheDocument();
         expect(screen.getByText(empty_portfolio_message)).toBeInTheDocument();
-        expect(screen.getByText(go_to_reports)).toBeInTheDocument();
     });
     it('should render Recent positions with empty portfolio message if there is an error in portfolio even though there is match in open position', () => {
         mocked_store.portfolio.error = 'Some error';
@@ -88,12 +93,21 @@ describe('<PositionsDrawer />', () => {
         ] as TAllPositions;
         render(mockPositionsDrawer(mockStore(mocked_store)));
 
-        expect(screen.getByText(recent_positions)).toBeInTheDocument();
+        expect(screen.getByText(open_positions)).toBeInTheDocument();
         expect(screen.getByText(empty_portfolio_message)).toBeInTheDocument();
-        expect(screen.getByText(go_to_reports)).toBeInTheDocument();
     });
     it('should render PositionsDrawerCard if portfolio is not empty and there is no error', () => {
         mocked_store.portfolio.error = '';
+        mocked_store.modules.trade.contract_type = TRADE_TYPES.VANILLA.CALL;
+        mocked_store.portfolio.all_positions = [
+            {
+                contract_info: mockContractInfo({
+                    underlying: '1HZ100V',
+                    contract_type: CONTRACT_TYPES.VANILLA.CALL,
+                    shortcode: 'VANILLALONGCALL_1HZ100V_10.00_1699697112_1699697772_S0P_2.33136_1699697111',
+                }),
+            },
+        ] as TAllPositions;
         render(mockPositionsDrawer(mockStore(mocked_store)));
 
         expect(screen.queryByText(empty_portfolio_message)).not.toBeInTheDocument();
@@ -143,12 +157,174 @@ describe('<PositionsDrawer />', () => {
 
         expect(screen.getAllByText(position_drawer_card)).toHaveLength(2);
     });
-    it('should call onHoverPosition if user hover on position drawer card and should call it twice if he unhover it', () => {
+    it('should call onHoverPosition if user hover on position drawer card and should call it twice if he unhover it', async () => {
+        mocked_store.modules.trade.contract_type = TRADE_TYPES.VANILLA.CALL;
+        mocked_store.portfolio.all_positions = [
+            {
+                contract_info: mockContractInfo({
+                    underlying: '1HZ100V',
+                    contract_type: CONTRACT_TYPES.VANILLA.CALL,
+                    shortcode: 'VANILLALONGCALL_1HZ100V_10.00_1699697112_1699697772_S0P_2.33136_1699697111',
+                }),
+            },
+            {
+                contract_info: mockContractInfo({
+                    underlying: '1HZ100V',
+                    contract_type: CONTRACT_TYPES.VANILLA.PUT,
+                    shortcode: 'VANILLALONGPUT_1HZ100V_10.00_1699697112_1699697772_S0P_2.33136_1699697111',
+                }),
+            },
+        ] as TAllPositions;
         render(mockPositionsDrawer(mockStore(mocked_store)));
 
-        userEvent.hover(screen.getAllByText(position_drawer_card)[0]);
-        userEvent.unhover(screen.getAllByText(position_drawer_card)[0]);
+        await userEvent.hover(screen.getAllByText(position_drawer_card)[0]);
+        await userEvent.unhover(screen.getAllByText(position_drawer_card)[0]);
 
         expect(mocked_store.portfolio.onHoverPosition).toBeCalledTimes(2);
+    });
+
+    describe('Total P/L calculations', () => {
+        it('should show correct total P/L for multiple positions with profits', () => {
+            mocked_store.portfolio.all_positions = [
+                {
+                    contract_info: mockContractInfo({
+                        profit: 100,
+                        currency: 'USD',
+                    }),
+                },
+                {
+                    contract_info: mockContractInfo({
+                        profit: 50,
+                        currency: 'USD',
+                    }),
+                },
+            ] as TAllPositions;
+
+            render(mockPositionsDrawer(mockStore(mocked_store)));
+
+            expect(screen.getByText('Total P/L:')).toBeInTheDocument();
+            expect(screen.getByTestId('dt_span')).toHaveTextContent('150.00');
+            expect(screen.getByText(/\+/)).toBeInTheDocument();
+            expect(screen.getByText(/USD/)).toBeInTheDocument();
+        });
+
+        it('should show correct total P/L for positions with losses', () => {
+            mocked_store.portfolio.all_positions = [
+                {
+                    contract_info: mockContractInfo({
+                        profit: -75,
+                        currency: 'USD',
+                    }),
+                },
+                {
+                    contract_info: mockContractInfo({
+                        profit: -25,
+                        currency: 'USD',
+                    }),
+                },
+            ] as TAllPositions;
+
+            render(mockPositionsDrawer(mockStore(mocked_store)));
+
+            expect(screen.getByText('Total P/L:')).toBeInTheDocument();
+            expect(screen.getByTestId('dt_span')).toHaveTextContent('100.00');
+            expect(screen.getByText(/-/)).toBeInTheDocument();
+            expect(screen.getByText(/USD/)).toBeInTheDocument();
+        });
+
+        it('should handle positions with mixed profits and losses', () => {
+            mocked_store.portfolio.all_positions = [
+                {
+                    contract_info: mockContractInfo({
+                        profit: 100,
+                        currency: 'USD',
+                    }),
+                },
+                {
+                    contract_info: mockContractInfo({
+                        profit: -60,
+                        currency: 'USD',
+                    }),
+                },
+            ] as TAllPositions;
+
+            render(mockPositionsDrawer(mockStore(mocked_store)));
+
+            expect(screen.getByText('Total P/L:')).toBeInTheDocument();
+            expect(screen.getByTestId('dt_span')).toHaveTextContent('40.00');
+            expect(screen.getByText(/USD/)).toBeInTheDocument();
+        });
+
+        it('should handle positions with zero total P/L', () => {
+            mocked_store.portfolio.all_positions = [
+                {
+                    contract_info: mockContractInfo({
+                        profit: 50,
+                        currency: 'USD',
+                    }),
+                },
+                {
+                    contract_info: mockContractInfo({
+                        profit: -50,
+                        currency: 'USD',
+                    }),
+                },
+            ] as TAllPositions;
+
+            render(mockPositionsDrawer(mockStore(mocked_store)));
+
+            expect(screen.getByText('Total P/L:')).toBeInTheDocument();
+            expect(screen.getByTestId('dt_span')).toHaveTextContent('0.00');
+            expect(screen.getByText(/USD/)).toBeInTheDocument();
+            expect(screen.getByText(/0\.00/)).toBeInTheDocument();
+        });
+
+        it('should handle positions with different currency', () => {
+            mocked_store.client.currency = 'EUR';
+            mocked_store.portfolio.all_positions = [
+                {
+                    contract_info: mockContractInfo({
+                        profit: 100,
+                        currency: 'EUR',
+                    }),
+                },
+            ] as TAllPositions;
+
+            render(mockPositionsDrawer(mockStore(mocked_store)));
+
+            expect(screen.getByText('Total P/L:')).toBeInTheDocument();
+            expect(screen.getByTestId('dt_span')).toHaveTextContent('100.00');
+            expect(screen.getByText(/EUR/)).toBeInTheDocument();
+        });
+
+        it('should not show total P/L section when there are no positions', () => {
+            mocked_store.portfolio.all_positions = [] as TAllPositions;
+
+            render(mockPositionsDrawer(mockStore(mocked_store)));
+
+            expect(screen.queryByText('Total P/L:')).not.toBeInTheDocument();
+        });
+
+        it('should handle positions with undefined profit values', () => {
+            mocked_store.portfolio.all_positions = [
+                {
+                    contract_info: mockContractInfo({
+                        profit: undefined,
+                        currency: 'USD',
+                    }),
+                },
+                {
+                    contract_info: mockContractInfo({
+                        profit: 50,
+                        currency: 'USD',
+                    }),
+                },
+            ] as TAllPositions;
+
+            render(mockPositionsDrawer(mockStore(mocked_store)));
+
+            expect(screen.getByText('Total P/L:')).toBeInTheDocument();
+            expect(screen.getByTestId('dt_span')).toHaveTextContent('50.00');
+        });
     });
 });

--- a/packages/trader/src/App/Components/Elements/PositionsDrawer/positions-drawer.tsx
+++ b/packages/trader/src/App/Components/Elements/PositionsDrawer/positions-drawer.tsx
@@ -185,7 +185,7 @@ const PositionsDrawer = observer(({ ...props }) => {
                         <div className='positions-drawer__summary'>
                             <Text size='xxs' color='less-prominent' className='positions-drawer__count'>
                                 {active_positions.length}{' '}
-                                {localize(`${active_positions.length > 1 ? 'open positions' : 'open position'}`)}
+                                {`${active_positions.length > 1 ? localize('open positions') : localize('open position')}`}
                             </Text>
                             <div className='positions-drawer__total'>
                                 <Text size='xs' weight='bold'>

--- a/packages/trader/src/sass/app/_common/drawer/positions-drawer.scss
+++ b/packages/trader/src/sass/app/_common/drawer/positions-drawer.scss
@@ -20,7 +20,9 @@ $header-height: 3.6em;
     opacity: 0;
     transform: translateX(-100%);
     will-change: transform, opacity;
-    transition: opacity 0.3s ease, transform 0.3s ease;
+    transition:
+        opacity 0.3s ease,
+        transform 0.3s ease;
     border-radius: $BORDER_RADIUS;
     border: 1px solid var(--general-section-1);
     background-color: var(--general-section-1);
@@ -93,8 +95,31 @@ $header-height: 3.6em;
         position: relative;
         height: 6em;
         display: flex;
-        justify-content: center;
         align-items: center;
+        box-shadow: 0px -1px 4px 0px #0000000a;
+        box-shadow: 0px -1px 4px 0px #00000014;
+
+        .positions-drawer__summary {
+            margin: 0 1.6rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.8rem;
+            width: 100%;
+        }
+
+        .positions-drawer__count {
+            line-height: 1.4;
+        }
+
+        .positions-drawer__total {
+            display: flex;
+            gap: 0.4rem;
+            align-items: center;
+            justify-content: space-between;
+            .dc-text {
+                line-height: 1.4;
+            }
+        }
 
         &:before {
             content: '';


### PR DESCRIPTION
fix: added total p/l functionality for desktop app

Removed go to reports button and added total p/l block
P/L calculation set on current active trades
Updated Positions drawer to only show active trades
Removed filtering on positions drawer for current market (all active trades will be displayed)
Total P/L block to be removed when no trades are active