### PR TITLE
Nijil/ TRAH-5819 / Redirect to OS or account settings page based on feature flag

### DIFF
--- a/packages/appstore/src/components/modals/verification-docs-list-modal/ListItem.tsx
+++ b/packages/appstore/src/components/modals/verification-docs-list-modal/ListItem.tsx
@@ -95,7 +95,7 @@ const ListItem = observer(({ id, text, status, route }: TListItemProps) => {
         }
         setVerificationModalOpen(false);
         if (id === 'identity' && status) {
-            if (true || (isRedirectToAccountsOSAppFFLoaded && shouldRedirectToAccountsOSApp)) {
+            if (isRedirectToAccountsOSAppFFLoaded && shouldRedirectToAccountsOSApp) {
                 const redirect_url =
                     status === 'none' || status === 'required' ? ACCOUNTS_OS_POI_URL : ACCOUNTS_OS_POI_STATUS_URL;
                 window.location.replace(getFormattedURL(redirect_url));

--- a/packages/appstore/src/components/modals/verification-docs-list-modal/ListItem.tsx
+++ b/packages/appstore/src/components/modals/verification-docs-list-modal/ListItem.tsx
@@ -1,13 +1,21 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
+import classNames from 'classnames';
 import { observer, useStore } from '@deriv/stores';
 import { LabelPairedChevronRightMdRegularIcon } from '@deriv/quill-icons';
-import { useHistory } from 'react-router-dom';
+import { useGrowthbookGetFeatureValue } from '@deriv/hooks';
 import { Localize } from '@deriv/translations';
 import { Text, StatusBadge } from '@deriv/components';
-import { AUTH_STATUS_CODES } from '@deriv/shared';
-import './verification-docs-list-modal.scss';
+import {
+    ACCOUNTS_OS_POI_STATUS_URL,
+    ACCOUNTS_OS_POI_URL,
+    ACCOUNTS_OS_POA_URL,
+    AUTH_STATUS_CODES,
+    getSocketURL,
+} from '@deriv/shared';
 import { useDevice } from '@deriv-com/ui';
-import classNames from 'classnames';
+import { WebSocketUtils } from '@deriv-com/utils';
+import './verification-docs-list-modal.scss';
 
 type TListItemProps = {
     id: string;
@@ -16,7 +24,7 @@ type TListItemProps = {
     route: string;
 };
 
-type TAuthStatusCodes = typeof AUTH_STATUS_CODES[keyof typeof AUTH_STATUS_CODES];
+type TAuthStatusCodes = (typeof AUTH_STATUS_CODES)[keyof typeof AUTH_STATUS_CODES];
 
 const getBadgeStatus = (status: TAuthStatusCodes) => {
     switch (status) {
@@ -49,24 +57,62 @@ const getBadgeStatus = (status: TAuthStatusCodes) => {
 
 const ListItem = observer(({ id, text, status, route }: TListItemProps) => {
     const { text: badge_text, icon: badge_icon, icon_size: badge_size } = getBadgeStatus(status);
-    const { traders_hub, ui } = useStore();
+    const { client, common, traders_hub, ui } = useStore();
     const { isMobile } = useDevice();
+    const { getToken } = client;
+    const { is_from_tradershub_os } = common;
     const { setVerificationModalOpen } = traders_hub;
     const history = useHistory();
     const is_document_verified = status === AUTH_STATUS_CODES.VERIFIED;
+    const [shouldRedirectToAccountsOSApp, isRedirectToAccountsOSAppFFLoaded] = useGrowthbookGetFeatureValue({
+        featureFlag: 'redirect_to_poi_in_accounts_os',
+    });
+
+    const getFormattedURL = (url_link: string) => {
+        const url = new URL(url_link);
+        const urlParams = new URLSearchParams(location.search);
+        const platformConfig = urlParams.get('platform') ?? window.sessionStorage.getItem('config.platform');
+        const platform = platformConfig ?? (is_from_tradershub_os ? 'tradershub_os' : 'deriv_app');
+
+        const params = {
+            platform,
+            appid: WebSocketUtils.getAppId(),
+            lang: 'en',
+            server: getSocketURL(),
+            token: getToken(),
+        };
+
+        Object.entries(params).forEach(([key, value]) => {
+            url.searchParams.append(key, value);
+        });
+
+        return url.toString();
+    };
 
     const onClickItem = () => {
         if (is_document_verified) {
             return;
         }
-        if (id === 'tax') {
-            ui.setFieldRefToFocus('employment-tax-section');
+        setVerificationModalOpen(false);
+        if (id === 'identity' && status) {
+            if (true || (isRedirectToAccountsOSAppFFLoaded && shouldRedirectToAccountsOSApp)) {
+                const redirect_url =
+                    status === 'none' || status === 'required' ? ACCOUNTS_OS_POI_URL : ACCOUNTS_OS_POI_STATUS_URL;
+                window.location.replace(getFormattedURL(redirect_url));
+                return;
+            }
         }
         if (id === 'address' && status) {
             localStorage.setItem('mt5_poa_status', String(status));
+            if (isRedirectToAccountsOSAppFFLoaded && shouldRedirectToAccountsOSApp) {
+                window.location.replace(getFormattedURL(ACCOUNTS_OS_POA_URL));
+                return;
+            }
+        }
+        if (id === 'tax') {
+            ui.setFieldRefToFocus('employment-tax-section');
         }
         history.push(route);
-        setVerificationModalOpen(false);
     };
 
     return (

--- a/packages/appstore/src/components/modals/verification-docs-list-modal/__tests__/Listitem.spec.tsx
+++ b/packages/appstore/src/components/modals/verification-docs-list-modal/__tests__/Listitem.spec.tsx
@@ -1,20 +1,44 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ListItem from '../ListItem';
 import { StoreProvider, mockStore } from '@deriv/stores';
 import { useDevice } from '@deriv-com/ui';
-import { useGetStatus, useIsSelectedMT5AccountCreated } from '@deriv/hooks';
-import { AUTH_STATUS_CODES } from '@deriv/shared';
+import { useGetStatus, useIsSelectedMT5AccountCreated, useGrowthbookGetFeatureValue } from '@deriv/hooks';
+import { AUTH_STATUS_CODES, ACCOUNTS_OS_POI_URL, ACCOUNTS_OS_POI_STATUS_URL, ACCOUNTS_OS_POA_URL } from '@deriv/shared';
 
 jest.mock('@deriv-com/ui', () => ({
     ...jest.requireActual('@deriv-com/ui'),
     useDevice: jest.fn(),
 }));
 
+const mockHistoryPush = jest.fn();
+const mockLocationReplace = jest.fn();
+const mockLocalStorage = {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+};
+
+// Mock window.location.replace
+Object.defineProperty(window, 'location', {
+    value: {
+        ...window.location,
+        replace: mockLocationReplace,
+    },
+    writable: true,
+});
+
+// Mock localStorage
+Object.defineProperty(window, 'localStorage', {
+    value: mockLocalStorage,
+    writable: true,
+});
+
 jest.mock('@deriv/hooks', () => ({
     ...jest.requireActual('@deriv/hooks'),
     useGetStatus: jest.fn(),
     useIsSelectedMT5AccountCreated: jest.fn(),
+    useGrowthbookGetFeatureValue: jest.fn(() => [false, true]),
 }));
 
 jest.mock('@deriv/quill-icons', () => ({
@@ -41,18 +65,28 @@ jest.mock('@deriv/shared', () => ({
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useHistory: () => ({
-        push: jest.fn(),
+        push: mockHistoryPush,
         location: { search: 'test' },
     }),
 }));
 
 describe('<ListItem />', () => {
+    const mockSetVerificationModalOpen = jest.fn();
+    const mockSetFieldRefToFocus = jest.fn();
+
     const defaultStore = mockStore({
         traders_hub: {
-            setVerificationModalOpen: jest.fn(),
+            setVerificationModalOpen: mockSetVerificationModalOpen,
         },
         common: {
             platform: 'mt5',
+            is_from_tradershub_os: false,
+        },
+        client: {
+            getToken: jest.fn(() => 'mock-token'),
+        },
+        ui: {
+            setFieldRefToFocus: mockSetFieldRefToFocus,
         },
     });
 
@@ -71,6 +105,7 @@ describe('<ListItem />', () => {
             client_kyc_status: { poi_status: 'verified', poa_status: 'verified', valid_tin: 'verified' },
         });
         (useIsSelectedMT5AccountCreated as jest.Mock).mockReturnValue({ is_selected_MT5_account_created: true });
+        (useGrowthbookGetFeatureValue as jest.Mock).mockReturnValue([false, true]);
     });
 
     it('should render verified status', () => {
@@ -113,5 +148,153 @@ describe('<ListItem />', () => {
         expect(screen.getByText('Failed')).toBeInTheDocument();
         expect(screen.getByText('StatusBadge')).toBeInTheDocument();
         expect(screen.getByText('LabelPairedChevronRightMdRegularIcon')).toBeInTheDocument();
+    });
+
+    it('should redirect to identity page when feature flag is disabled', async () => {
+        (useGrowthbookGetFeatureValue as jest.Mock).mockReturnValue([false, true]);
+
+        const props = {
+            id: 'identity',
+            text: 'Identity',
+            status: 'none',
+            route: '/proof_of_identity',
+        };
+        renderComponent(props);
+
+        const identityItem = screen.getByText('Identity');
+        fireEvent.click(identityItem);
+
+        await waitFor(() => {
+            expect(mockSetVerificationModalOpen).toHaveBeenCalledWith(false);
+            expect(mockHistoryPush).toHaveBeenCalledWith('/proof_of_identity');
+            expect(mockLocationReplace).not.toHaveBeenCalled();
+        });
+    });
+
+    it('should redirect to accounts OS app for identity when feature flag is enabled and status is none', async () => {
+        (useGrowthbookGetFeatureValue as jest.Mock).mockReturnValue([true, true]);
+
+        const props = {
+            id: 'identity',
+            text: 'Identity',
+            status: 'none',
+            route: '/proof_of_identity',
+        };
+        renderComponent(props);
+
+        const identityItem = screen.getByText('Identity');
+        fireEvent.click(identityItem);
+
+        await waitFor(() => {
+            expect(mockSetVerificationModalOpen).toHaveBeenCalledWith(false);
+            expect(mockLocationReplace).toHaveBeenCalled();
+            expect(mockLocationReplace.mock.calls[0][0]).toContain(ACCOUNTS_OS_POI_URL);
+            expect(mockHistoryPush).not.toHaveBeenCalled();
+        });
+    });
+
+    it('should redirect to accounts OS status page for identity when feature flag is enabled and status is not none', async () => {
+        (useGrowthbookGetFeatureValue as jest.Mock).mockReturnValue([true, true]);
+
+        const props = {
+            id: 'identity',
+            text: 'Identity',
+            status: 'pending',
+            route: '/proof_of_identity',
+        };
+        renderComponent(props);
+
+        const identityItem = screen.getByText('Identity');
+        fireEvent.click(identityItem);
+
+        await waitFor(() => {
+            expect(mockSetVerificationModalOpen).toHaveBeenCalledWith(false);
+            expect(mockLocationReplace).toHaveBeenCalled();
+            expect(mockLocationReplace.mock.calls[0][0]).toContain(ACCOUNTS_OS_POI_STATUS_URL);
+            expect(mockHistoryPush).not.toHaveBeenCalled();
+        });
+    });
+
+    it('should set localStorage and redirect to address page when feature flag is disabled', async () => {
+        (useGrowthbookGetFeatureValue as jest.Mock).mockReturnValue([false, true]);
+
+        const props = {
+            id: 'address',
+            text: 'Address',
+            status: 'none',
+            route: '/proof_of_address',
+        };
+        renderComponent(props);
+
+        const addressItem = screen.getByText('Address');
+        fireEvent.click(addressItem);
+
+        await waitFor(() => {
+            expect(mockSetVerificationModalOpen).toHaveBeenCalledWith(false);
+            expect(mockLocalStorage.setItem).toHaveBeenCalledWith('mt5_poa_status', 'none');
+            expect(mockHistoryPush).toHaveBeenCalledWith('/proof_of_address');
+            expect(mockLocationReplace).not.toHaveBeenCalled();
+        });
+    });
+
+    it('should set localStorage and redirect to accounts OS app for address when feature flag is enabled', async () => {
+        (useGrowthbookGetFeatureValue as jest.Mock).mockReturnValue([true, true]);
+
+        const props = {
+            id: 'address',
+            text: 'Address',
+            status: 'none',
+            route: '/proof_of_address',
+        };
+        renderComponent(props);
+
+        const addressItem = screen.getByText('Address');
+        fireEvent.click(addressItem);
+
+        await waitFor(() => {
+            expect(mockSetVerificationModalOpen).toHaveBeenCalledWith(false);
+            expect(mockLocalStorage.setItem).toHaveBeenCalledWith('mt5_poa_status', 'none');
+            expect(mockLocationReplace).toHaveBeenCalled();
+            expect(mockLocationReplace.mock.calls[0][0]).toContain(ACCOUNTS_OS_POA_URL);
+            expect(mockHistoryPush).not.toHaveBeenCalled();
+        });
+    });
+
+    it('should not do anything when document is verified', async () => {
+        const props = {
+            id: 'identity',
+            text: 'Identity',
+            status: AUTH_STATUS_CODES.VERIFIED,
+            route: '/proof_of_identity',
+        };
+        renderComponent(props);
+
+        const identityItem = screen.getByText('Identity');
+        fireEvent.click(identityItem);
+
+        await waitFor(() => {
+            expect(mockSetVerificationModalOpen).not.toHaveBeenCalled();
+            expect(mockHistoryPush).not.toHaveBeenCalled();
+            expect(mockLocationReplace).not.toHaveBeenCalled();
+        });
+    });
+
+    it('should set field ref to focus for tax information', async () => {
+        const props = {
+            id: 'tax',
+            text: 'Tax information',
+            status: 'none',
+            route: '/personal_details',
+        };
+        renderComponent(props);
+
+        const taxItem = screen.getByText('Tax information');
+        fireEvent.click(taxItem);
+
+        await waitFor(() => {
+            expect(mockSetVerificationModalOpen).toHaveBeenCalledWith(false);
+            expect(mockSetFieldRefToFocus).toHaveBeenCalledWith('employment-tax-section');
+            expect(mockHistoryPush).toHaveBeenCalledWith('/personal_details');
+        });
     });
 });

--- a/packages/wallets/src/components/ClientVerificationModal/components/DocumentsList/DocumentsList.tsx
+++ b/packages/wallets/src/components/ClientVerificationModal/components/DocumentsList/DocumentsList.tsx
@@ -42,16 +42,16 @@ const DocumentsList: React.FC<TDocumentsListProps> = ({ account }) => {
         featureFlag: 'redirect_to_poi_in_accounts_os',
     });
 
-    const getFormattedURL = (url_link: string) => {
-        const url = new URL(url_link);
+    const getFormattedURL = (urlLink: string) => {
+        const url = new URL(urlLink);
         const urlParams = new URLSearchParams(location.search);
         const platformConfig = urlParams.get('platform') ?? window.sessionStorage.getItem('config.platform');
         const platform = platformConfig ?? (isNavigationFromTradersHubOS() ? 'tradershub_os' : 'deriv_app');
 
         const params = {
-            platform,
             appid: getAppId(),
             lang: 'en',
+            platform,
             server: getSocketURL(),
             token: getToken(activeWallet?.loginid || ''),
         };
@@ -71,10 +71,9 @@ const DocumentsList: React.FC<TDocumentsListProps> = ({ account }) => {
                     disabled={!isPoiRequired}
                     onClick={() => {
                         if (isRedirectToAccountsOSAppFFLoaded && shouldRedirectToAccountsOSApp) {
-                            const { poi_status } = account.client_kyc_status;
-                            const redirect_url =
-                                poi_status === 'none' ? ACCOUNTS_OS_POI_URL : ACCOUNTS_OS_POI_STATUS_URL;
-                            window.location.replace(getFormattedURL(redirect_url));
+                            const { poi_status: poiStatus } = account.client_kyc_status;
+                            const redirectUrl = poiStatus === 'none' ? ACCOUNTS_OS_POI_URL : ACCOUNTS_OS_POI_STATUS_URL;
+                            window.location.replace(getFormattedURL(redirectUrl));
                         } else {
                             // @ts-expect-error the following link is not part of wallets routes config
                             history.push('/account/proof-of-identity');

--- a/packages/wallets/src/components/ClientVerificationModal/components/DocumentsList/__tests__/DocumentsList.spec.tsx
+++ b/packages/wallets/src/components/ClientVerificationModal/components/DocumentsList/__tests__/DocumentsList.spec.tsx
@@ -9,8 +9,8 @@ const mockHistoryPush = jest.fn();
 const mockLocationReplace = jest.fn();
 const mockLocalStorage = {
     getItem: jest.fn(),
-    setItem: jest.fn(),
     removeItem: jest.fn(),
+    setItem: jest.fn(),
 };
 
 // Mock the window.location.replace function
@@ -35,8 +35,8 @@ beforeEach(() => {
     mockLocalStorage.setItem.mockReset();
 
     // Default mock for useGrowthbookGetFeatureValue
-    (useGrowthbookGetFeatureValue as jest.Mock).mockReturnValue([false, true]);
     (useActiveWalletAccount as jest.Mock).mockReturnValue({ data: { loginid: '123' } });
+    (useGrowthbookGetFeatureValue as jest.Mock).mockReturnValue([false, true]);
 });
 
 jest.mock('react-router-dom', () => ({

--- a/packages/wallets/src/components/ClientVerificationModal/components/DocumentsList/__tests__/DocumentsList.spec.tsx
+++ b/packages/wallets/src/components/ClientVerificationModal/components/DocumentsList/__tests__/DocumentsList.spec.tsx
@@ -1,15 +1,56 @@
 import React from 'react';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useGrowthbookGetFeatureValue, useActiveWalletAccount } from '@deriv/api-v2';
+import { ACCOUNTS_OS_POI_STATUS_URL, ACCOUNTS_OS_POI_URL, ACCOUNTS_OS_POA_URL } from '@deriv/shared';
 import DocumentsList from '../DocumentsList';
 
 const mockHistoryPush = jest.fn();
+const mockLocationReplace = jest.fn();
+const mockLocalStorage = {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+};
+
+// Mock the window.location.replace function
+Object.defineProperty(window, 'location', {
+    value: {
+        ...window.location,
+        replace: mockLocationReplace,
+    },
+    writable: true,
+});
+
+beforeEach(() => {
+    // Mock localStorage
+    Object.defineProperty(window, 'localStorage', {
+        value: mockLocalStorage,
+        writable: true,
+    });
+
+    // Reset mocks
+    mockHistoryPush.mockReset();
+    mockLocationReplace.mockReset();
+    mockLocalStorage.setItem.mockReset();
+
+    // Default mock for useGrowthbookGetFeatureValue
+    (useGrowthbookGetFeatureValue as jest.Mock).mockReturnValue([false, true]);
+    (useActiveWalletAccount as jest.Mock).mockReturnValue({ data: { loginid: '123' } });
+});
 
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useHistory: jest.fn(() => ({
         push: mockHistoryPush,
     })),
+}));
+
+// Mock the API hooks
+jest.mock('@deriv/api-v2', () => ({
+    ...jest.requireActual('@deriv/api-v2'),
+    useGrowthbookGetFeatureValue: jest.fn(() => [false, true]),
+    useActiveWalletAccount: jest.fn(() => ({ data: { loginid: '123' } })),
 }));
 
 jest.mock('../../../../ClientVerificationBadge', () => ({
@@ -76,7 +117,9 @@ describe('<DocumentsList />', () => {
         expect(screen.queryByText('Additional information')).not.toBeInTheDocument();
     });
 
-    it('on click poi tile redirects to correct page', async () => {
+    it('on click poi tile redirects to correct page when feature flag is disabled', async () => {
+        (useGrowthbookGetFeatureValue as jest.Mock).mockReturnValue([false, true]);
+
         render(
             <DocumentsList
                 account={{
@@ -93,10 +136,63 @@ describe('<DocumentsList />', () => {
 
         await waitFor(() => {
             expect(mockHistoryPush).toBeCalledWith('/account/proof-of-identity');
+            expect(mockLocationReplace).not.toBeCalled();
         });
     });
 
-    it('on click poa tile redirects to correct page', async () => {
+    it('on click poi tile redirects to accounts OS app when feature flag is enabled and poi_status is none', async () => {
+        (useGrowthbookGetFeatureValue as jest.Mock).mockReturnValue([true, true]);
+
+        render(
+            <DocumentsList
+                account={{
+                    // @ts-expect-error - since this is a mock, we only need partial properties of the account
+                    client_kyc_status: {
+                        poi_status: 'none',
+                    },
+                }}
+            />
+        );
+
+        const poiTile = screen.getByText('Proof of identity');
+        await userEvent.click(poiTile);
+
+        await waitFor(() => {
+            expect(mockLocationReplace).toBeCalled();
+            // Check that the URL contains the POI URL for new submissions
+            expect(mockLocationReplace.mock.calls[0][0]).toContain(ACCOUNTS_OS_POI_URL);
+            expect(mockHistoryPush).not.toBeCalled();
+        });
+    });
+
+    it('on click poi tile redirects to accounts OS status page when feature flag is enabled and poi_status is not none', async () => {
+        (useGrowthbookGetFeatureValue as jest.Mock).mockReturnValue([true, true]);
+
+        render(
+            <DocumentsList
+                account={{
+                    // @ts-expect-error - since this is a mock, we only need partial properties of the account
+                    client_kyc_status: {
+                        poi_status: 'pending',
+                    },
+                }}
+            />
+        );
+
+        const poiTile = screen.getByText('Proof of identity');
+        await userEvent.click(poiTile);
+
+        await waitFor(() => {
+            expect(mockLocationReplace).toBeCalled();
+            // Check that the URL contains the POI status URL for existing submissions
+            expect(mockLocationReplace.mock.calls[0][0]).toContain(ACCOUNTS_OS_POI_STATUS_URL);
+            expect(mockHistoryPush).not.toBeCalled();
+        });
+    });
+
+    it('on click poa tile redirects to correct page when feature flag is disabled', async () => {
+        (useGrowthbookGetFeatureValue as jest.Mock).mockReturnValue([false, true]);
+
         render(
             <DocumentsList
                 account={{
@@ -113,6 +209,75 @@ describe('<DocumentsList />', () => {
 
         await waitFor(() => {
             expect(mockHistoryPush).toBeCalledWith('/account/proof-of-address');
+            expect(mockLocationReplace).not.toBeCalled();
+        });
+    });
+
+    it('on click poa tile redirects to accounts OS app when feature flag is enabled', async () => {
+        (useGrowthbookGetFeatureValue as jest.Mock).mockReturnValue([true, true]);
+
+        render(
+            <DocumentsList
+                account={{
+                    // @ts-expect-error - since this is a mock, we only need partial properties of the account
+                    client_kyc_status: {
+                        poa_status: 'none',
+                    },
+                }}
+            />
+        );
+
+        const poaTile = screen.getByText('Proof of address');
+        await userEvent.click(poaTile);
+
+        await waitFor(() => {
+            expect(mockLocationReplace).toBeCalled();
+            // Check that the URL contains the POA URL
+            expect(mockLocationReplace.mock.calls[0][0]).toContain(ACCOUNTS_OS_POA_URL);
+            expect(mockHistoryPush).not.toBeCalled();
+        });
+    });
+
+    it('sets localStorage when account platform is mt5', async () => {
+        render(
+            <DocumentsList
+                account={{
+                    // @ts-expect-error - since this is a mock, we only need partial properties of the account
+                    client_kyc_status: {
+                        poa_status: 'verified',
+                    },
+                    platform: 'mt5',
+                }}
+            />
+        );
+
+        const poaTile = screen.getByText('Proof of address');
+        await userEvent.click(poaTile);
+
+        await waitFor(() => {
+            expect(mockLocalStorage.setItem).toHaveBeenCalledWith('mt5_poa_status', 'verified');
+        });
+    });
+
+    it('does not set localStorage when account platform is not mt5', async () => {
+        render(
+            <DocumentsList
+                account={{
+                    // @ts-expect-error - since this is a mock, we only need partial properties of the account
+                    client_kyc_status: {
+                        poa_status: 'verified',
+                    },
+                    // Using a different platform that's not mt5
+                    platform: 'dxtrade' as any,
+                }}
+            />
+        );
+
+        const poaTile = screen.getByText('Proof of address');
+        await userEvent.click(poaTile);
+
+        await waitFor(() => {
+            expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/wallets/src/components/ClientVerificationModal/components/DocumentsList/__tests__/DocumentsList.spec.tsx
+++ b/packages/wallets/src/components/ClientVerificationModal/components/DocumentsList/__tests__/DocumentsList.spec.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import { useActiveWalletAccount, useGrowthbookGetFeatureValue } from '@deriv/api-v2';
+import { ACCOUNTS_OS_POA_URL, ACCOUNTS_OS_POI_STATUS_URL, ACCOUNTS_OS_POI_URL } from '@deriv/shared';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useGrowthbookGetFeatureValue, useActiveWalletAccount } from '@deriv/api-v2';
-import { ACCOUNTS_OS_POI_STATUS_URL, ACCOUNTS_OS_POI_URL, ACCOUNTS_OS_POA_URL } from '@deriv/shared';
 import DocumentsList from '../DocumentsList';
 
 const mockHistoryPush = jest.fn();
@@ -49,8 +49,8 @@ jest.mock('react-router-dom', () => ({
 // Mock the API hooks
 jest.mock('@deriv/api-v2', () => ({
     ...jest.requireActual('@deriv/api-v2'),
-    useGrowthbookGetFeatureValue: jest.fn(() => [false, true]),
     useActiveWalletAccount: jest.fn(() => ({ data: { loginid: '123' } })),
+    useGrowthbookGetFeatureValue: jest.fn(() => [false, true]),
 }));
 
 jest.mock('../../../../ClientVerificationBadge', () => ({
@@ -268,6 +268,7 @@ describe('<DocumentsList />', () => {
                         poa_status: 'verified',
                     },
                     // Using a different platform that's not mt5
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     platform: 'dxtrade' as any,
                 }}
             />


### PR DESCRIPTION
## Changes:
Before - While creating a CFD account that requires POI/POA verification, clicking on POI/POA first redirects to the high-code account settings page before opening the low-code account settings page, causing an inconsistent redirection flow.

Fix - Redirect to OS or account settings page based on feature flag value when creating a CFD account that requires POI/POA verification.