### PR TITLE
Moiz - GRWT-5659 - [DTrader] Show the Guide video's toolbar at the beginning

### DIFF
--- a/packages/components/src/components/video-player/video-player.tsx
+++ b/packages/components/src/components/video-player/video-player.tsx
@@ -19,6 +19,7 @@ type TVideoPlayerProps = {
     src: string;
     show_loading?: boolean;
     onModalClose?: () => void;
+    is_tutorial?: boolean;
 };
 type TSupportedEvent = React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement> | TouchEvent | MouseEvent;
 
@@ -38,6 +39,7 @@ const VideoPlayer = ({
     src,
     show_loading = false,
     onModalClose,
+    is_tutorial = false,
 }: TVideoPlayerProps) => {
     const is_rtl = useIsRtl();
 
@@ -51,7 +53,18 @@ const VideoPlayer = ({
     const [is_playing, setIsPlaying] = React.useState(false);
     const [is_muted, setIsMuted] = React.useState(muted);
     const [playback_rate, setPlaybackRate] = React.useState(1);
-    const [show_controls, setShowControls] = React.useState(!should_autoplay);
+    const [show_controls, setShowControls] = React.useState(is_tutorial ? true : !should_autoplay);
+    const [is_in_initial_period, setIsInInitialPeriod] = React.useState(is_tutorial);
+
+    React.useEffect(() => {
+        if (is_tutorial) {
+            const tutorial_timeout = setTimeout(() => {
+                setShowControls(false);
+                setIsInInitialPeriod(false);
+            }, 5000);
+            return () => clearTimeout(tutorial_timeout);
+        }
+    }, [is_tutorial]);
     const [shift_X, setShiftX] = React.useState(0);
     const [video_duration, setVideoDuration] = React.useState<number>();
     const [volume, setVolume] = React.useState(0.5);
@@ -332,8 +345,8 @@ const VideoPlayer = ({
     return (
         <div
             className={classNames(className, 'player__wrapper')}
-            onMouseOver={is_mobile ? undefined : () => setShowControls(true)}
-            onMouseLeave={is_mobile ? undefined : () => setShowControls(false)}
+            onMouseOver={is_mobile || is_in_initial_period ? undefined : () => setShowControls(true)}
+            onMouseLeave={is_mobile || is_in_initial_period ? undefined : () => setShowControls(false)}
             data-testid={data_testid}
         >
             <Stream

--- a/packages/trader/src/Assets/Trading/Categories/contract-type-description-video.tsx
+++ b/packages/trader/src/Assets/Trading/Categories/contract-type-description-video.tsx
@@ -20,6 +20,7 @@ const ContractTypeDescriptionVideo = ({ data_testid, selected_contract_type }: T
                 src={getDescriptionVideoId(selected_contract_type, is_dark_theme)}
                 is_mobile={is_mobile}
                 data_testid={data_testid}
+                is_tutorial={true}
             />
         </div>
     );


### PR DESCRIPTION
… default

fix: added logic for playback controls to be visible for 5 seconds by default during which move actions wont hide the controls after the five seconds have passed mouse in will display the controls and move out will hide them

### Screenshots:

https://github.com/user-attachments/assets/020659ea-2ad6-436f-94ed-71c9a06d7639

