### PR TITLE
amam/fix-highcode-logout

### DIFF
--- a/packages/core/src/App/Containers/Layout/header/default-header-wallets.tsx
+++ b/packages/core/src/App/Containers/Layout/header/default-header-wallets.tsx
@@ -58,6 +58,8 @@ const DefaultHeaderWallets = () => {
 
     const history = useHistory();
 
+    const isRedirectPage = history.location.pathname.includes(routes.redirect);
+
     const { isDesktop } = useDevice();
 
     const addUpdateNotification = () => addNotificationMessage(client_notifications.new_version_available);
@@ -128,7 +130,7 @@ const DefaultHeaderWallets = () => {
                         'header__menu-right--hidden': is_mobile && is_logging_in,
                     })}
                 >
-                    {(is_logging_in || is_single_logging_in || is_switching) && (
+                    {(is_logging_in || is_single_logging_in || is_switching || isRedirectPage) && (
                         <div
                             id='dt_core_header_acc-info-preloader'
                             className={classNames('acc-info__preloader', {

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -2212,6 +2212,7 @@ export default class ClientStore extends BaseStore {
         if (response?.logout === 1) {
             await this.cleanUp();
 
+            this.setIsSingleLoggingIn(false);
             this.setLogout(true);
             this.setIsLoggingOut(false);
         }

--- a/packages/hooks/src/__tests__/useOauth2.spec.tsx
+++ b/packages/hooks/src/__tests__/useOauth2.spec.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useOAuth2 } from '@deriv-com/auth-client';
 import useGrowthbookGetFeatureValue from '../useGrowthbookGetFeatureValue';
 import useOauth2 from '../useOauth2';
+import { StoreProvider, mockStore } from '@deriv/stores';
 
 jest.mock('@deriv-com/auth-client', () => ({
     useIsOAuth2Enabled: jest.fn(),
@@ -23,7 +24,14 @@ describe('useOauth2', () => {
 
     it('should return oAuthLogout', () => {
         const handleLogout = jest.fn().mockResolvedValue(undefined);
-        const { result } = renderHook(() => useOauth2({ handleLogout }));
+
+        const mockRootStore = mockStore({});
+
+        const wrapper = ({ children }: { children: JSX.Element }) => (
+            <StoreProvider store={mockRootStore}>{children}</StoreProvider>
+        );
+
+        const { result } = renderHook(() => useOauth2({ handleLogout }), { wrapper });
         expect(typeof result.current.oAuthLogout).toBe('function');
     });
 });

--- a/packages/hooks/src/__tests__/useOauth2.spec.tsx
+++ b/packages/hooks/src/__tests__/useOauth2.spec.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { useOAuth2 } from '@deriv-com/auth-client';
 import useGrowthbookGetFeatureValue from '../useGrowthbookGetFeatureValue';

--- a/packages/hooks/src/useOauth2.ts
+++ b/packages/hooks/src/useOauth2.ts
@@ -1,6 +1,7 @@
 import { redirectToLogin } from '@deriv/shared';
-import { getLanguage } from '@deriv/translations';
+import { getLanguage, localize } from '@deriv/translations';
 import { OAuth2Logout, requestOidcAuthentication } from '@deriv-com/auth-client';
+import { useStore } from '@deriv/stores';
 
 /**
  * Provides an object with one properties: `oAuthLogout`.
@@ -15,6 +16,7 @@ import { OAuth2Logout, requestOidcAuthentication } from '@deriv-com/auth-client'
  */
 const useOauth2 = ({ handleLogout }: { handleLogout: () => Promise<void> }) => {
     const is_deriv_com = /deriv\.(com)/.test(window.location.hostname);
+    const { common, client } = useStore();
     const loginHandler = async () => {
         if (is_deriv_com) {
             try {
@@ -29,16 +31,34 @@ const useOauth2 = ({ handleLogout }: { handleLogout: () => Promise<void> }) => {
                 // eslint-disable-next-line no-console
                 console.error(err);
             }
+        } else {
+            redirectToLogin(false, getLanguage());
         }
-        redirectToLogin(false, getLanguage());
     };
 
     const logoutHandler = async () => {
-        await OAuth2Logout({
-            WSLogoutAndRedirect: handleLogout,
-            redirectCallbackUri: `${window.location.origin}/callback`,
-            postLogoutRedirectUri: `${window.location.origin}/`,
-        });
+        try {
+            await OAuth2Logout({
+                WSLogoutAndRedirect: handleLogout,
+                redirectCallbackUri: `${window.location.origin}/callback`,
+                postLogoutRedirectUri: `${window.location.origin}/`,
+            });
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error(error);
+
+            client.setIsSingleLoggingIn(false);
+
+            if (common.setError) {
+                common.setError(true, {
+                    code: 'LogoutError',
+                    message: localize('Failed while logging out, please login'),
+                    should_show_refresh: false,
+                    redirect_label: localize('Log in'),
+                    redirectOnClick: () => loginHandler(),
+                });
+            }
+        }
     };
 
     return { oAuthLogout: logoutHandler, loginHandler };


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of login/logout flows, error management, and UI updates in the application. The most significant updates include adding error handling for OAuth2 logout, enhancing the `DefaultHeaderWallets` component to account for redirect pages, and ensuring proper state management during logout.

### Enhancements to login/logout flows and error handling:

* **Improved OAuth2 logout error handling**: Added a `try-catch` block in the `logoutHandler` function to handle errors during OAuth2 logout. If an error occurs, the `client.setIsSingleLoggingIn` method is called to reset the state, and the `common.setError` method is used to display an error message with a login redirect option. (`packages/hooks/src/useOauth2.ts`, [packages/hooks/src/useOauth2.tsL32-R61](diffhunk://#diff-08909aacedb83acf77f8e2305ce10d2092aaf875dcd23cd0529305fb235ffeabL32-R61))

* **Added `useStore` for state management**: Imported and utilized `useStore` in the `useOauth2` hook to manage `common` and `client` states for error handling and state updates during login/logout. (`packages/hooks/src/useOauth2.ts`, [[1]](diffhunk://#diff-08909aacedb83acf77f8e2305ce10d2092aaf875dcd23cd0529305fb235ffeabL2-R4) [[2]](diffhunk://#diff-08909aacedb83acf77f8e2305ce10d2092aaf875dcd23cd0529305fb235ffeabR19)

* **Updated `ClientStore` logout logic**: Ensured that `setIsSingleLoggingIn` is set to `false` when the user logs out to properly manage the state. (`packages/core/src/Stores/client-store.js`, [packages/core/src/Stores/client-store.jsR2215](diffhunk://#diff-ca1070ada988963eae4e734a9a2389b2fb4b76a0a6ffa3f2f0112e67e2ecb53cR2215))

### UI updates:

* **Handled redirect pages in `DefaultHeaderWallets`**: Added a check for `isRedirectPage` in the `DefaultHeaderWallets` component to ensure the preloader is displayed when on a redirect page. (`packages/core/src/App/Containers/Layout/header/default-header-wallets.tsx`, [[1]](diffhunk://#diff-24a57c4aef6cca6efc720df091ad7ff5ea01d4309755c95286d7a8f8cde4187aR61-R62) [[2]](diffhunk://#diff-24a57c4aef6cca6efc720df091ad7ff5ea01d4309755c95286d7a8f8cde4187aL131-R133)