### PR TITLE
amam/fix-logout-highcode-wallet rc

### DIFF
--- a/packages/core/src/App/Containers/Layout/header/default-header-wallets.tsx
+++ b/packages/core/src/App/Containers/Layout/header/default-header-wallets.tsx
@@ -58,6 +58,8 @@ const DefaultHeaderWallets = () => {
 
     const history = useHistory();
 
+    const isRedirectPage = history.location.pathname.includes(routes.redirect);
+
     const { isDesktop } = useDevice();
 
     const addUpdateNotification = () => addNotificationMessage(client_notifications.new_version_available);
@@ -128,7 +130,7 @@ const DefaultHeaderWallets = () => {
                         'header__menu-right--hidden': is_mobile && is_logging_in,
                     })}
                 >
-                    {(is_logging_in || is_single_logging_in || is_switching) && (
+                    {(is_logging_in || is_single_logging_in || is_switching || isRedirectPage) && (
                         <div
                             id='dt_core_header_acc-info-preloader'
                             className={classNames('acc-info__preloader', {

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -2212,6 +2212,7 @@ export default class ClientStore extends BaseStore {
         if (response?.logout === 1) {
             await this.cleanUp();
 
+            this.setIsSingleLoggingIn(false);
             this.setLogout(true);
             this.setIsLoggingOut(false);
         }

--- a/packages/hooks/src/useOauth2.ts
+++ b/packages/hooks/src/useOauth2.ts
@@ -1,6 +1,7 @@
 import { redirectToLogin } from '@deriv/shared';
-import { getLanguage } from '@deriv/translations';
+import { getLanguage, localize } from '@deriv/translations';
 import { OAuth2Logout, requestOidcAuthentication } from '@deriv-com/auth-client';
+import { useStore } from '@deriv/stores';
 
 /**
  * Provides an object with one properties: `oAuthLogout`.
@@ -15,6 +16,7 @@ import { OAuth2Logout, requestOidcAuthentication } from '@deriv-com/auth-client'
  */
 const useOauth2 = ({ handleLogout }: { handleLogout: () => Promise<void> }) => {
     const is_deriv_com = /deriv\.(com)/.test(window.location.hostname);
+    const { common, client } = useStore();
     const loginHandler = async () => {
         if (is_deriv_com) {
             try {
@@ -29,16 +31,34 @@ const useOauth2 = ({ handleLogout }: { handleLogout: () => Promise<void> }) => {
                 // eslint-disable-next-line no-console
                 console.error(err);
             }
+        } else {
+            redirectToLogin(false, getLanguage());
         }
-        redirectToLogin(false, getLanguage());
     };
 
     const logoutHandler = async () => {
-        await OAuth2Logout({
-            WSLogoutAndRedirect: handleLogout,
-            redirectCallbackUri: `${window.location.origin}/callback`,
-            postLogoutRedirectUri: `${window.location.origin}/`,
-        });
+        try {
+            await OAuth2Logout({
+                WSLogoutAndRedirect: handleLogout,
+                redirectCallbackUri: `${window.location.origin}/callback`,
+                postLogoutRedirectUri: `${window.location.origin}/`,
+            });
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error(error);
+
+            client.setIsSingleLoggingIn(false);
+
+            if (common.setError) {
+                common.setError(true, {
+                    code: 'LogoutError',
+                    message: localize('Failed while logging out, please login'),
+                    should_show_refresh: false,
+                    redirect_label: localize('Log in'),
+                    redirectOnClick: () => loginHandler(),
+                });
+            }
+        }
     };
 
     return { oAuthLogout: logoutHandler, loginHandler };


### PR DESCRIPTION
This pull request introduces enhancements to error handling, user experience improvements, and code maintainability across multiple components. The key changes include better handling of logout errors, improved preloader visibility logic, and the addition of new utility functions for localization and state management.

### Error Handling Improvements:
* [`packages/hooks/src/useOauth2.ts`](diffhunk://#diff-08909aacedb83acf77f8e2305ce10d2092aaf875dcd23cd0529305fb235ffeabL32-R61): Enhanced the `logoutHandler` function to catch and handle errors during logout. It now sets the `isSingleLoggingIn` state to `false` and displays an error message with a localized prompt to log in again.

### User Experience Enhancements:
* [`packages/core/src/App/Containers/Layout/header/default-header-wallets.tsx`](diffhunk://#diff-24a57c4aef6cca6efc720df091ad7ff5ea01d4309755c95286d7a8f8cde4187aL131-R133): Updated the preloader visibility logic to include a new condition (`isRedirectPage`) for better user feedback during redirection.
* [`packages/core/src/App/Containers/Layout/header/default-header-wallets.tsx`](diffhunk://#diff-24a57c4aef6cca6efc720df091ad7ff5ea01d4309755c95286d7a8f8cde4187aR61-R62): Added a new `isRedirectPage` variable to detect if the user is on a redirect page, improving the header's behavior during such scenarios.

### Code Maintainability:
* [`packages/core/src/Stores/client-store.js`](diffhunk://#diff-ca1070ada988963eae4e734a9a2389b2fb4b76a0a6ffa3f2f0112e67e2ecb53cR2215): Ensured the `isSingleLoggingIn` state is reset to `false` during the logout cleanup process to maintain consistent state management.
* [`packages/hooks/src/useOauth2.ts`](diffhunk://#diff-08909aacedb83acf77f8e2305ce10d2092aaf875dcd23cd0529305fb235ffeabL2-R4): Introduced the `useStore` hook and imported the `localize` function to streamline state management and localization within the `useOauth2` hook. [[1]](diffhunk://#diff-08909aacedb83acf77f8e2305ce10d2092aaf875dcd23cd0529305fb235ffeabL2-R4) [[2]](diffhunk://#diff-08909aacedb83acf77f8e2305ce10d2092aaf875dcd23cd0529305fb235ffeabR19)