### PR TITLE
Niloofar/86c3jcquh/Replace hub_enabled_country_list with Firebase Config

### DIFF
--- a/packages/api-v2/src/hooks/useIsHubRedirectionEnabled.ts
+++ b/packages/api-v2/src/hooks/useIsHubRedirectionEnabled.ts
@@ -1,34 +1,26 @@
 import useClientCountry from './useClientCountry';
-import useGrowthbookGetFeatureValue from './useGrowthbookGetFeatureValue';
+import useRemoteConfig from './useRemoteConfig';
 import useSettings from './useSettings';
 
-type THubEnabledCountryList = {
-    hub_enabled_country_list: string[];
-};
-
 const useIsHubRedirectionEnabled = () => {
-    const [hubEnabledCountryList] = useGrowthbookGetFeatureValue({
-        featureFlag: 'hub_enabled_country_list',
-    });
+    const { data } = useRemoteConfig();
+    const hub_enabled_country_list = data?.hub_enabled_country_list ?? [];
+
     const { data: clientCountry } = useClientCountry();
     const { data: accountSettings } = useSettings();
-    const { country_code: countryCode } = accountSettings;
+    const countryCode = accountSettings?.country_code;
 
     const isHubRedirectionEnabled =
-        typeof hubEnabledCountryList === 'object' &&
-        hubEnabledCountryList !== null &&
-        Array.isArray((hubEnabledCountryList as THubEnabledCountryList).hub_enabled_country_list) &&
-        countryCode &&
-        (hubEnabledCountryList as THubEnabledCountryList).hub_enabled_country_list.includes(countryCode);
+        Array.isArray(hub_enabled_country_list) && countryCode && hub_enabled_country_list.includes(countryCode);
 
     const isChangingToHubAppId =
-        typeof hubEnabledCountryList === 'object' &&
-        hubEnabledCountryList !== null &&
-        Array.isArray((hubEnabledCountryList as THubEnabledCountryList).hub_enabled_country_list) &&
-        clientCountry &&
-        (hubEnabledCountryList as THubEnabledCountryList).hub_enabled_country_list.includes(clientCountry);
+        Array.isArray(hub_enabled_country_list) && clientCountry && hub_enabled_country_list.includes(clientCountry);
 
-    return { isHubRedirectionEnabled, isChangingToHubAppId };
+    return {
+        isHubRedirectionEnabled,
+        isChangingToHubAppId,
+        isHubRedirectionLoaded: !!hub_enabled_country_list.length,
+    };
 };
 
 export default useIsHubRedirectionEnabled;


### PR DESCRIPTION
## Changes:

- Replaced `hub_enabled_country_list` from Growthbook with Firebase Remote Config (useRemoteConfig).
- Fixed the incorrect redirection when navigating from DTrader to the Wallet page.