### PR TITLE
Niloofar/Remove Error Page Flicker Before Relogin

### DIFF
--- a/packages/core/src/App/AppContent.tsx
+++ b/packages/core/src/App/AppContent.tsx
@@ -84,9 +84,6 @@ const AppContent: React.FC<{ passthrough: unknown }> = observer(({ passthrough }
     const [isCountryCodeDropdownEnabled, isCountryCodeDropdownGBLoaded] = useGrowthbookGetFeatureValue({
         featureFlag: 'enable_country_code_dropdown',
     });
-    const [isDuplicateLoginEnabled] = useGrowthbookGetFeatureValue({
-        featureFlag: 'duplicate-login',
-    });
 
     const { data } = useRemoteConfig(true);
     const { tracking_datadog } = data;
@@ -178,7 +175,7 @@ const AppContent: React.FC<{ passthrough: unknown }> = observer(({ passthrough }
                     <Routes passthrough={passthrough} />
                 </AppContents>
             </ErrorBoundary>
-            {!(isDuplicateLoginEnabled && has_access_denied_error) && <Footer />}
+            {!has_access_denied_error && <Footer />}
             <ErrorBoundary root_store={store}>
                 <AppModals />
             </ErrorBoundary>

--- a/packages/core/src/App/Containers/Layout/app-contents.jsx
+++ b/packages/core/src/App/Containers/Layout/app-contents.jsx
@@ -52,9 +52,6 @@ const AppContents = observer(({ children }) => {
     const [dtrader_v2_enabled_desktop] = useGrowthbookGetFeatureValue({
         featureFlag: 'dtrader_v2_enabled_desktop',
     });
-    const [isDuplicateLoginEnabled] = useGrowthbookGetFeatureValue({
-        featureFlag: 'duplicate-login',
-    });
     React.useEffect(() => {
         if (should_redirect_user_to_login) {
             setShouldRedirectToLogin(false);
@@ -137,8 +134,7 @@ const AppContents = observer(({ children }) => {
                 'app-contents--is-route-modal': is_route_modal_on,
                 'app-contents--is-scrollable': is_cfd_page || is_cashier_visible,
                 'app-contents--is-hidden':
-                    (isDuplicateLoginEnabled && has_access_denied_error) ||
-                    (platforms[platform] && !(is_from_tradershub_os && isMobile)),
+                    has_access_denied_error || (platforms[platform] && !(is_from_tradershub_os && isMobile)),
                 'app-contents--is-onboarding': window.location.pathname === routes.onboarding,
                 'app-contents--is-dtrader-v2': dtrader_v2_enabled_mobile || dtrader_v2_enabled_desktop,
             })}

--- a/packages/core/src/Modules/Callback/CallbackPage.tsx
+++ b/packages/core/src/Modules/Callback/CallbackPage.tsx
@@ -1,7 +1,6 @@
 import { useHistory, useLocation, withRouter } from 'react-router-dom';
 
 import { Button } from '@deriv/components';
-import { useGrowthbookGetFeatureValue } from '@deriv/hooks';
 import { routes } from '@deriv/shared';
 import { Localize } from '@deriv/translations';
 import { Callback } from '@deriv-com/auth-client';
@@ -13,11 +12,7 @@ const CallbackPage = () => {
     const location = useLocation();
     const has_access_denied_error = location.search.includes('access_denied');
 
-    const [isDuplicateLoginEnabled] = useGrowthbookGetFeatureValue({
-        featureFlag: 'duplicate-login',
-    });
-
-    if (isDuplicateLoginEnabled && has_access_denied_error) {
+    if (has_access_denied_error) {
         return <AccessDeniedScreen />;
     }
     return (


### PR DESCRIPTION
## Changes:
OIDC - Error Page Flicker:
A flicker of an error page was observed briefly before the relogin popup appeared during authentication flows. This update removes that flicker, providing a cleaner and more seamless user experience during session renewals.