### PR TITLE
Nijil / Account limits footer icon redirection

### DIFF
--- a/packages/core/src/App/Components/Layout/Footer/account-limits.jsx
+++ b/packages/core/src/App/Components/Layout/Footer/account-limits.jsx
@@ -1,17 +1,22 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { Icon, Popover } from '@deriv/components';
-import { routes } from '@deriv/shared';
+import { useAccountSettingsRedirect } from '@deriv/hooks';
 import { localize } from '@deriv/translations';
+import { observer } from '@deriv/stores';
 
-export const AccountLimits = ({ showPopover }) => (
-    <Link to={routes.account_limits} className='footer__link'>
-        {showPopover ? (
-            <Popover alignment='top' message={localize('Account limits')} zIndex={9999}>
+export const AccountLimits = observer(({ showPopover }) => {
+    // Use the useAccountSettingsRedirect hook with 'account-limits' as the redirect_to value
+    const { redirect_url } = useAccountSettingsRedirect('account-limits');
+
+    return (
+        <a className='footer__link' href={redirect_url}>
+            {showPopover ? (
+                <Popover alignment='top' message={localize('Account limits')} zIndex={9999}>
+                    <Icon icon='IcAccountLimits' className='footer__icon ic-deriv__icon' />
+                </Popover>
+            ) : (
                 <Icon icon='IcAccountLimits' className='footer__icon ic-deriv__icon' />
-            </Popover>
-        ) : (
-            <Icon icon='IcAccountLimits' className='footer__icon ic-deriv__icon' />
-        )}
-    </Link>
-);
+            )}
+        </a>
+    );
+});

--- a/packages/hooks/src/__tests__/useAccountSettingsRedirect.spec.ts
+++ b/packages/hooks/src/__tests__/useAccountSettingsRedirect.spec.ts
@@ -86,7 +86,7 @@ describe('useAccountSettingsRedirect', () => {
         expect(result.current.redirect_url).toBe(expectedUrl);
     });
 
-    it('should return hub URL when both conditions are true', () => {
+    it('should return hub URL with default redirect_to=home when both conditions are true', () => {
         (useStore as jest.Mock).mockReturnValue({
             client: {
                 has_wallet: true,
@@ -102,6 +102,26 @@ describe('useAccountSettingsRedirect', () => {
         // In test environment, we should always get the staging URL
         const expectedUrl =
             'https://staging-hub.deriv.com/accounts/redirect?action=redirect_to&redirect_to=home&account=demo';
+
+        expect(result.current.redirect_url).toBe(expectedUrl);
+    });
+
+    it('should use custom redirect_to value when provided', () => {
+        (useStore as jest.Mock).mockReturnValue({
+            client: {
+                has_wallet: true,
+            },
+        });
+
+        (useIsHubRedirectionEnabled as jest.Mock).mockReturnValue({
+            isHubRedirectionEnabled: true,
+        });
+
+        const { result } = renderHook(() => useAccountSettingsRedirect('account-limits'));
+
+        // In test environment, we should always get the staging URL with the custom redirect_to value
+        const expectedUrl =
+            'https://staging-hub.deriv.com/accounts/redirect?action=redirect_to&redirect_to=account-limits&account=demo';
 
         expect(result.current.redirect_url).toBe(expectedUrl);
     });
@@ -133,5 +153,44 @@ describe('useAccountSettingsRedirect', () => {
             'https://staging-hub.deriv.com/accounts/redirect?action=redirect_to&redirect_to=home&account=BTC';
 
         expect(result.current.redirect_url).toBe(expectedUrl);
+    });
+
+    it('should set both redirect_url and mobile_redirect_url with custom redirect_to value', () => {
+        (useStore as jest.Mock).mockReturnValue({
+            client: {
+                has_wallet: true,
+            },
+        });
+
+        (useIsHubRedirectionEnabled as jest.Mock).mockReturnValue({
+            isHubRedirectionEnabled: true,
+        });
+
+        const { result } = renderHook(() => useAccountSettingsRedirect('trading-assessment'));
+
+        // Both URLs should contain the custom redirect_to value
+        const expectedUrl =
+            'https://staging-hub.deriv.com/accounts/redirect?action=redirect_to&redirect_to=trading-assessment&account=demo';
+
+        expect(result.current.redirect_url).toBe(expectedUrl);
+        expect(result.current.mobile_redirect_url).toBe(expectedUrl);
+    });
+
+    it('should return deriv-app routes if isHubRedirectionEnabled is false', () => {
+        (useStore as jest.Mock).mockReturnValue({
+            client: {
+                has_wallet: false,
+            },
+        });
+
+        (useIsHubRedirectionEnabled as jest.Mock).mockReturnValue({
+            isHubRedirectionEnabled: false,
+        });
+
+        const { result } = renderHook(() => useAccountSettingsRedirect('custom-page'));
+
+        // Should still return the default routes regardless of the redirect_to parameter
+        expect(result.current.redirect_url).toBe(routes.personal_details);
+        expect(result.current.mobile_redirect_url).toBe(routes.account);
     });
 });

--- a/packages/hooks/src/useAccountSettingsRedirect.ts
+++ b/packages/hooks/src/useAccountSettingsRedirect.ts
@@ -3,7 +3,7 @@ import { useStore } from '@deriv/stores';
 
 import useIsHubRedirectionEnabled from './useIsHubRedirectionEnabled';
 
-export const useAccountSettingsRedirect = () => {
+export const useAccountSettingsRedirect = (redirect_to = 'home') => {
     const { client } = useStore();
     const { has_wallet } = client;
     const { isHubRedirectionEnabled } = useIsHubRedirectionEnabled();
@@ -19,8 +19,8 @@ export const useAccountSettingsRedirect = () => {
         const base_url =
             process.env.NODE_ENV === 'production' ? 'https://hub.deriv.com' : 'https://staging-hub.deriv.com';
 
-        redirect_url = `${base_url}/accounts/redirect?action=redirect_to&redirect_to=home&account=${account_type}`;
-        mobile_redirect_url = `${base_url}/accounts/redirect?action=redirect_to&redirect_to=home&account=${account_type}`;
+        redirect_url = `${base_url}/accounts/redirect?action=redirect_to&redirect_to=${redirect_to}&account=${account_type}`;
+        mobile_redirect_url = `${base_url}/accounts/redirect?action=redirect_to&redirect_to=${redirect_to}&account=${account_type}`;
     } else {
         redirect_url = routes.personal_details;
         mobile_redirect_url = routes.account;


### PR DESCRIPTION
## Changes:
Clicking on the "Account Limits" link in the Deriv App footer should redirect the user to the new low-code Account Limits page for hub enabled countries.