### PR TITLE
Fix EU redirect header flash

### DIFF
--- a/packages/core/src/App/Containers/Layout/header/header.tsx
+++ b/packages/core/src/App/Containers/Layout/header/header.tsx
@@ -56,6 +56,7 @@ const Header = observer(() => {
             routes.cashier,
             routes.wallets_compare_accounts,
             routes.compare_cfds,
+            routes.redirect,
         ].includes(pathname) ||
         pathname.startsWith(routes.compare_cfds) ||
         is_wallets_cashier_route;


### PR DESCRIPTION
## Summary
- show traders hub header on redirect page

## Testing
- `npm test` *(fails: stylelint not found)*