### PR TITLE
Farabi/grwt-6148/remove-sound-of-trade-types-videos

### DIFF
--- a/packages/components/src/components/video-player/__tests__/video-controls.spec.tsx
+++ b/packages/components/src/components/video-player/__tests__/video-controls.spec.tsx
@@ -8,28 +8,23 @@ const mocked_props: React.ComponentProps<typeof VideoControls> = {
     is_animated: true,
     is_ended: false,
     is_playing: true,
-    is_muted: false,
     onRewind: jest.fn(),
-    onVolumeChange: jest.fn(),
     onPlaybackRateChange: jest.fn(),
     progress_bar_filled_ref: { current: null },
     progress_bar_ref: { current: null },
     progress_dot_ref: { current: null },
     show_controls: true,
     togglePlay: jest.fn(),
-    toggleMute: jest.fn(),
     video_duration: 33,
-    volume: 0.5,
     playback_rate: 1,
+    onUserActivity: jest.fn(),
 };
 
-const volume_control = 'VolumeControl component';
 const playback_rate_control = 'PlaybackRateControl component';
 const progress_bar = 'dt_progress_bar';
 const progress_bar_filled = 'dt_progress_bar_filled';
 const progress_bar_dot = 'dt_progress_bar_dot';
 
-jest.mock('../volume-control', () => jest.fn(() => <div>{volume_control}</div>));
 jest.mock('../playback-rate-control', () => jest.fn(() => <div>{playback_rate_control}</div>));
 
 describe('<VideoControls />', () => {
@@ -39,7 +34,6 @@ describe('<VideoControls />', () => {
         expect(screen.getByTestId(progress_bar)).toBeInTheDocument();
         expect(screen.getByTestId(progress_bar_filled)).toBeInTheDocument();
         expect(screen.getByText(/00:03 \/ 00:33/i)).toBeInTheDocument();
-        expect(screen.getByText(volume_control)).toBeInTheDocument();
         expect(screen.getByText(playback_rate_control)).toBeInTheDocument();
     });
 

--- a/packages/components/src/components/video-player/video-controls.tsx
+++ b/packages/components/src/components/video-player/video-controls.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import Icon from '../icon';
 import Text from '../text';
 import { formatDurationTime } from '@deriv/shared';
+import VolumeControl from './volume-control';
 import PlaybackRateControl from './playback-rate-control';
 import clsx from 'clsx';
 
@@ -11,13 +12,16 @@ type TVideoControls = {
     current_time?: number;
     dragStartHandler: (e: React.MouseEvent<HTMLSpanElement> | React.TouchEvent<HTMLSpanElement>) => void;
     has_enlarged_dot?: boolean;
+    hide_volume_control?: boolean;
     is_animated?: boolean;
     is_ended?: boolean;
     is_playing?: boolean;
     is_mobile?: boolean;
+    is_muted?: boolean;
     is_v2?: boolean;
     increased_drag_area?: boolean;
     onRewind: (e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => void;
+    onVolumeChange: (new_value: number) => void;
     onPlaybackRateChange: (new_value: number) => void;
     onUserActivity: () => void;
     progress_bar_filled_ref: React.RefObject<HTMLDivElement>;
@@ -26,7 +30,9 @@ type TVideoControls = {
     playback_rate: number;
     show_controls?: boolean;
     togglePlay: (e: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>) => void;
+    toggleMute: (new_value: boolean) => void;
     video_duration?: number;
+    volume?: number;
 };
 
 const VideoControls = ({
@@ -34,13 +40,16 @@ const VideoControls = ({
     current_time,
     dragStartHandler,
     has_enlarged_dot,
+    hide_volume_control = false,
     is_animated,
     is_ended,
     is_playing,
     is_mobile,
+    is_muted,
     is_v2 = false,
     increased_drag_area,
     onRewind,
+    onVolumeChange,
     onPlaybackRateChange,
     progress_bar_filled_ref,
     progress_bar_ref,
@@ -48,7 +57,9 @@ const VideoControls = ({
     playback_rate,
     show_controls,
     togglePlay,
+    toggleMute,
     video_duration,
+    volume,
     onUserActivity,
 }: TVideoControls) => {
     const [is_drag_dot_visible, setIsDragDotVisible] = React.useState(false);
@@ -75,6 +86,16 @@ const VideoControls = ({
                     })}
                 >
                     <div className='controls__right--v2'>
+                        {!hide_volume_control && (
+                            <VolumeControl
+                                onVolumeChange={onVolumeChange}
+                                volume={volume}
+                                is_mobile={is_mobile}
+                                is_muted={is_muted}
+                                toggleMute={toggleMute}
+                                is_v2
+                            />
+                        )}
                         <PlaybackRateControl
                             onPlaybackRateChange={onPlaybackRateChange}
                             is_mobile={is_mobile}
@@ -150,6 +171,15 @@ const VideoControls = ({
                         </div>
                     </div>
                     <div className='player__controls__bottom-bar'>
+                        {!hide_volume_control && (
+                            <VolumeControl
+                                onVolumeChange={onVolumeChange}
+                                volume={volume}
+                                is_mobile={is_mobile}
+                                is_muted={is_muted}
+                                toggleMute={toggleMute}
+                            />
+                        )}
                         <PlaybackRateControl
                             onPlaybackRateChange={onPlaybackRateChange}
                             is_mobile={is_mobile}

--- a/packages/components/src/components/video-player/video-controls.tsx
+++ b/packages/components/src/components/video-player/video-controls.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 import Icon from '../icon';
 import Text from '../text';
 import { formatDurationTime } from '@deriv/shared';
-import VolumeControl from './volume-control';
 import PlaybackRateControl from './playback-rate-control';
 import clsx from 'clsx';
 
@@ -16,11 +15,9 @@ type TVideoControls = {
     is_ended?: boolean;
     is_playing?: boolean;
     is_mobile?: boolean;
-    is_muted?: boolean;
     is_v2?: boolean;
     increased_drag_area?: boolean;
     onRewind: (e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => void;
-    onVolumeChange: (new_value: number) => void;
     onPlaybackRateChange: (new_value: number) => void;
     onUserActivity: () => void;
     progress_bar_filled_ref: React.RefObject<HTMLDivElement>;
@@ -29,9 +26,7 @@ type TVideoControls = {
     playback_rate: number;
     show_controls?: boolean;
     togglePlay: (e: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>) => void;
-    toggleMute: (new_value: boolean) => void;
     video_duration?: number;
-    volume?: number;
 };
 
 const VideoControls = ({
@@ -43,11 +38,9 @@ const VideoControls = ({
     is_ended,
     is_playing,
     is_mobile,
-    is_muted,
     is_v2 = false,
     increased_drag_area,
     onRewind,
-    onVolumeChange,
     onPlaybackRateChange,
     progress_bar_filled_ref,
     progress_bar_ref,
@@ -55,9 +48,7 @@ const VideoControls = ({
     playback_rate,
     show_controls,
     togglePlay,
-    toggleMute,
     video_duration,
-    volume,
     onUserActivity,
 }: TVideoControls) => {
     const [is_drag_dot_visible, setIsDragDotVisible] = React.useState(false);
@@ -84,14 +75,6 @@ const VideoControls = ({
                     })}
                 >
                     <div className='controls__right--v2'>
-                        <VolumeControl
-                            onVolumeChange={onVolumeChange}
-                            volume={volume}
-                            is_mobile={is_mobile}
-                            is_muted={is_muted}
-                            toggleMute={toggleMute}
-                            is_v2
-                        />
                         <PlaybackRateControl
                             onPlaybackRateChange={onPlaybackRateChange}
                             is_mobile={is_mobile}
@@ -166,14 +149,7 @@ const VideoControls = ({
                             </Text>
                         </div>
                     </div>
-                    <div className='player__controls__bottom-bar controls__right'>
-                        <VolumeControl
-                            onVolumeChange={onVolumeChange}
-                            volume={volume}
-                            is_mobile={is_mobile}
-                            is_muted={is_muted}
-                            toggleMute={toggleMute}
-                        />
+                    <div className='player__controls__bottom-bar'>
                         <PlaybackRateControl
                             onPlaybackRateChange={onPlaybackRateChange}
                             is_mobile={is_mobile}

--- a/packages/components/src/components/video-player/video-player.tsx
+++ b/packages/components/src/components/video-player/video-player.tsx
@@ -15,7 +15,6 @@ type TVideoPlayerProps = {
     is_mobile?: boolean;
     is_v2?: boolean;
     increased_drag_area?: boolean;
-    muted?: boolean;
     src: string;
     show_loading?: boolean;
     onModalClose?: () => void;
@@ -35,7 +34,6 @@ const VideoPlayer = ({
     is_mobile,
     is_v2,
     increased_drag_area,
-    muted = false,
     src,
     show_loading = false,
     onModalClose,
@@ -51,7 +49,6 @@ const VideoPlayer = ({
     const [is_animated, setIsAnimated] = React.useState(true);
     const [is_loading, setIsLoading] = React.useState(true);
     const [is_playing, setIsPlaying] = React.useState(false);
-    const [is_muted, setIsMuted] = React.useState(muted);
     const [playback_rate, setPlaybackRate] = React.useState(1);
     const [show_controls, setShowControls] = React.useState(should_show_controls ? true : !should_autoplay);
     const [is_in_initial_period, setIsInInitialPeriod] = React.useState(should_show_controls);
@@ -67,7 +64,6 @@ const VideoPlayer = ({
     }, [should_show_controls]);
     const [shift_X, setShiftX] = React.useState(0);
     const [video_duration, setVideoDuration] = React.useState<number>();
-    const [volume, setVolume] = React.useState(0.5);
 
     const video_ref = React.useRef<StreamPlayerApi>();
     const progress_bar_filled_ref = React.useRef<HTMLDivElement>(null);
@@ -355,7 +351,7 @@ const VideoPlayer = ({
                 className={classNames('', { player: is_v2 })}
                 width='100%'
                 letterboxColor='transparent'
-                muted={is_muted}
+                muted={true}
                 preload='auto'
                 responsive={is_v2 ? undefined : false}
                 src={src}
@@ -366,7 +362,7 @@ const VideoPlayer = ({
                 onSeeked={() => (should_check_time_ref.current = true)}
                 onSeeking={() => (should_check_time_ref.current = true)}
                 playbackRate={playback_rate}
-                volume={volume}
+                volume={0}
             />
             {is_loading && show_loading && (
                 <div className='player__loader' style={{ height: height ?? (is_mobile ? '184.5px' : '270px') }}>
@@ -392,17 +388,13 @@ const VideoPlayer = ({
                 is_ended={is_ended.current}
                 is_playing={is_playing}
                 is_mobile={is_mobile}
-                is_muted={is_muted}
                 is_v2={is_v2}
                 increased_drag_area={increased_drag_area}
                 onRewind={onRewind}
-                onVolumeChange={setVolume}
                 onPlaybackRateChange={setPlaybackRate}
                 show_controls={show_controls}
                 togglePlay={togglePlay}
-                toggleMute={setIsMuted}
                 video_duration={video_duration}
-                volume={volume}
                 progress_bar_filled_ref={progress_bar_filled_ref}
                 progress_bar_ref={progress_bar_ref}
                 progress_dot_ref={progress_dot_ref}

--- a/packages/components/src/components/video-player/video-player.tsx
+++ b/packages/components/src/components/video-player/video-player.tsx
@@ -12,9 +12,11 @@ type TVideoPlayerProps = {
     className?: string;
     data_testid?: string;
     height?: string;
+    hide_volume_control?: boolean;
     is_mobile?: boolean;
     is_v2?: boolean;
     increased_drag_area?: boolean;
+    muted?: boolean;
     src: string;
     show_loading?: boolean;
     onModalClose?: () => void;
@@ -31,9 +33,11 @@ const VideoPlayer = ({
     className,
     data_testid,
     height,
+    hide_volume_control = false,
     is_mobile,
     is_v2,
     increased_drag_area,
+    muted = false,
     src,
     show_loading = false,
     onModalClose,
@@ -49,6 +53,7 @@ const VideoPlayer = ({
     const [is_animated, setIsAnimated] = React.useState(true);
     const [is_loading, setIsLoading] = React.useState(true);
     const [is_playing, setIsPlaying] = React.useState(false);
+    const [is_muted, setIsMuted] = React.useState(muted);
     const [playback_rate, setPlaybackRate] = React.useState(1);
     const [show_controls, setShowControls] = React.useState(should_show_controls ? true : !should_autoplay);
     const [is_in_initial_period, setIsInInitialPeriod] = React.useState(should_show_controls);
@@ -64,6 +69,7 @@ const VideoPlayer = ({
     }, [should_show_controls]);
     const [shift_X, setShiftX] = React.useState(0);
     const [video_duration, setVideoDuration] = React.useState<number>();
+    const [volume, setVolume] = React.useState(0.5);
 
     const video_ref = React.useRef<StreamPlayerApi>();
     const progress_bar_filled_ref = React.useRef<HTMLDivElement>(null);
@@ -148,7 +154,7 @@ const VideoPlayer = ({
         cancelAnimationFrame(animation_ref.current);
         debouncedRewind.cancel();
         is_dragging.current = false;
-        should_check_time_ref.current = true;
+        should_check_time_ref.current = false;
 
         debouncedRewind();
 
@@ -176,7 +182,7 @@ const VideoPlayer = ({
         video_ref.current.currentTime = new_time;
         new_time_ref.current = new_time;
         setCurrentTime(new_time);
-        should_check_time_ref.current = true;
+        should_check_time_ref.current = false;
 
         debouncedRewind();
     };
@@ -351,7 +357,7 @@ const VideoPlayer = ({
                 className={classNames('', { player: is_v2 })}
                 width='100%'
                 letterboxColor='transparent'
-                muted={true}
+                muted={is_muted}
                 preload='auto'
                 responsive={is_v2 ? undefined : false}
                 src={src}
@@ -359,10 +365,10 @@ const VideoPlayer = ({
                 onEnded={onEnded}
                 onPlay={() => setIsPlaying(true)}
                 onLoadedMetaData={onLoadedMetaData}
-                onSeeked={() => (should_check_time_ref.current = true)}
-                onSeeking={() => (should_check_time_ref.current = true)}
+                onSeeked={() => (should_check_time_ref.current = false)}
+                onSeeking={() => (should_check_time_ref.current = false)}
                 playbackRate={playback_rate}
-                volume={0}
+                volume={volume}
             />
             {is_loading && show_loading && (
                 <div className='player__loader' style={{ height: height ?? (is_mobile ? '184.5px' : '270px') }}>
@@ -384,17 +390,22 @@ const VideoPlayer = ({
                 current_time={current_time}
                 dragStartHandler={dragStartHandler}
                 has_enlarged_dot={has_enlarged_dot}
+                hide_volume_control={hide_volume_control}
                 is_animated={is_animated}
                 is_ended={is_ended.current}
                 is_playing={is_playing}
                 is_mobile={is_mobile}
+                is_muted={is_muted}
                 is_v2={is_v2}
                 increased_drag_area={increased_drag_area}
                 onRewind={onRewind}
+                onVolumeChange={setVolume}
                 onPlaybackRateChange={setPlaybackRate}
                 show_controls={show_controls}
                 togglePlay={togglePlay}
+                toggleMute={setIsMuted}
                 video_duration={video_duration}
+                volume={volume}
                 progress_bar_filled_ref={progress_bar_filled_ref}
                 progress_bar_ref={progress_bar_ref}
                 progress_dot_ref={progress_dot_ref}

--- a/packages/trader/src/Assets/Trading/Categories/contract-type-description-video.tsx
+++ b/packages/trader/src/Assets/Trading/Categories/contract-type-description-video.tsx
@@ -21,6 +21,8 @@ const ContractTypeDescriptionVideo = ({ data_testid, selected_contract_type }: T
                 is_mobile={is_mobile}
                 data_testid={data_testid}
                 should_show_controls={true}
+                muted={true}
+                hide_volume_control={true}
             />
         </div>
     );


### PR DESCRIPTION
This pull request removes the volume control functionality from the video player component, simplifying the codebase and standardizing the player to always be muted with a volume of 0. The changes involve removing related props, state variables, and the `VolumeControl` component.

### Removal of Volume Control Functionality:

* `packages/components/src/components/video-player/video-controls.tsx`:
  - Removed `VolumeControl` imports, props (`is_muted`, `onVolumeChange`, `toggleMute`, `volume`), and references to the `VolumeControl` component. [[1]](diffhunk://#diff-135eaa452ee347b90aab8706c743adf9070219d8c9de337576a57dacea7ed40aL6) [[2]](diffhunk://#diff-135eaa452ee347b90aab8706c743adf9070219d8c9de337576a57dacea7ed40aL19-L23) [[3]](diffhunk://#diff-135eaa452ee347b90aab8706c743adf9070219d8c9de337576a57dacea7ed40aL32-L34) [[4]](diffhunk://#diff-135eaa452ee347b90aab8706c743adf9070219d8c9de337576a57dacea7ed40aL46-L60) [[5]](diffhunk://#diff-135eaa452ee347b90aab8706c743adf9070219d8c9de337576a57dacea7ed40aL87-L94) [[6]](diffhunk://#diff-135eaa452ee347b90aab8706c743adf9070219d8c9de337576a57dacea7ed40aL169-R152)

* `packages/components/src/components/video-player/video-player.tsx`:
  - Removed `muted` and `volume` props and state variables (`is_muted`, `volume`) from the `VideoPlayer` component. [[1]](diffhunk://#diff-31ec9af8fdd987a3954795dcc32b778aaa1f0ca3d3622463ec71ed3024212576L18) [[2]](diffhunk://#diff-31ec9af8fdd987a3954795dcc32b778aaa1f0ca3d3622463ec71ed3024212576L38) [[3]](diffhunk://#diff-31ec9af8fdd987a3954795dcc32b778aaa1f0ca3d3622463ec71ed3024212576L54) [[4]](diffhunk://#diff-31ec9af8fdd987a3954795dcc32b778aaa1f0ca3d3622463ec71ed3024212576L70)
  - Hardcoded the `muted` property to `true` and the `volume` property to `0` in the video player configuration. [[1]](diffhunk://#diff-31ec9af8fdd987a3954795dcc32b778aaa1f0ca3d3622463ec71ed3024212576L358-R354) [[2]](diffhunk://#diff-31ec9af8fdd987a3954795dcc32b778aaa1f0ca3d3622463ec71ed3024212576L369-R365)
  - Removed references to `is_muted`, `onVolumeChange`, `toggleMute`, and `volume` when passing props to `VideoControls`.

These changes simplify the video player component by eliminating unused functionality and ensuring consistent behavior across all use cases.
