### PR TITLE
chore(trader): remove NEW labels from trade types

### DIFF
--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-list.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-list.tsx
@@ -38,8 +38,6 @@ const List = ({ handleSelect, list, should_show_info_banner, value }: TListProps
                 return [...acc, { ...contract_type, value: newValue }];
             }, []);
 
-            const is_new = /(Accumulators|Turbos|Vanillas)/i.test(contract_category.key);
-
             return (
                 <div
                     key={contract_category.key}
@@ -53,11 +51,6 @@ const List = ({ handleSelect, list, should_show_info_banner, value }: TListProps
                         <Text size='xs' className='contract-type-list__label'>
                             {contract_category.label}
                         </Text>
-                        {is_new && (
-                            <span className={classNames('dc-vertical-tab__header--new', 'contract-type-item__new')}>
-                                {localize('NEW!')}
-                            </span>
-                        )}
                     </div>
                     <div className='contract-type-list__wrapper'>
                         <Item

--- a/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-widget.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/ContractType/contract-type-widget.tsx
@@ -229,9 +229,6 @@ const ContractTypeWidget = observer(
                 categories.push({
                     label: localize('Options'),
                     contract_categories: options_category,
-                    component: options_category.some(category => /Vanillas|Turbos/i.test(category.key)) ? (
-                        <span className='dc-vertical-tab__header--new'>{localize('NEW')}!</span>
-                    ) : null,
                     key: 'Options',
                     icon: '',
                 });
@@ -241,7 +238,6 @@ const ContractTypeWidget = observer(
                 categories.push({
                     label: localize('Accumulators'),
                     contract_categories: accumulators_category,
-                    component: <span className='dc-vertical-tab__header--new'>{localize('NEW')}!</span>,
                     key: 'Accumulators',
                     icon: '',
                 });

--- a/packages/trader/src/Modules/Trading/Helpers/contract-type.tsx
+++ b/packages/trader/src/Modules/Trading/Helpers/contract-type.tsx
@@ -80,10 +80,6 @@ export const getAvailableContractTypes = (
                     label: contract_name,
                     contract_types: available_contract_types,
                     icon: contract_category_icon[contract_name],
-                    component:
-                        contract_name === localize('Accumulators') ? (
-                            <span className='dc-vertical-tab__header--new'>{localize('NEW!')}</span>
-                        ) : null,
                 };
             }
             return undefined;


### PR DESCRIPTION
## Summary
- remove `NEW` badge from trade types and categories

## Testing
- `npm run test:eslint-all` *(fails: nx not found)*