### PR TITLE
Fix: Remove !NEW label from Accumulators trade type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48769,7 +48769,6 @@
             "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.13.1.tgz",
             "integrity": "sha512-Mv+BQr5XTUrKqAXmpqm6Ddli6Ief+AiPZkRsIrAoUKFuq/ElkUh9ZMYxXD0iQNZ5ADghZKLOWz1h7hTClB7zgQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@stylelint/postcss-css-in-js": "^0.37.2",
                 "@stylelint/postcss-markdown": "^0.36.2",

--- a/packages/trader/src/Modules/Trading/Helpers/contract-type.tsx
+++ b/packages/trader/src/Modules/Trading/Helpers/contract-type.tsx
@@ -80,10 +80,6 @@ export const getAvailableContractTypes = (
                     label: contract_name,
                     contract_types: available_contract_types,
                     icon: contract_category_icon[contract_name],
-                    component:
-                        contract_name === localize('Accumulators') ? (
-                            <span className='dc-vertical-tab__header--new'>{localize('NEW!')}</span>
-                        ) : null,
                 };
             }
             return undefined;
@@ -100,7 +96,6 @@ export const getAvailableContractTypes = (
             | 'IcDigits'
             | 'IcMultiplier'
             | 'IcCatAccumulator';
-        component: JSX.Element | null;
     }[];
 };
 


### PR DESCRIPTION
I removed the component property from the getAvailableContractTypes function in packages/trader/src/Modules/Trading/Helpers/contract-type.tsx to eliminate the "!NEW" label from the Accumulators trade type in the menu.

Note: Some tests related to contract types
(packages/trader/src/Modules/Trading/Containers/__tests__/contract-type.spec.tsx and packages/trader/src/Modules/Trading/Helpers/__tests__/contract-type.spec.tsx) timed out during verification and may require your further investigation.

## Changes:

Please provide a summary of the change.

### Screenshots:

Please provide some screenshots of the change.
