### PR TITLE
Nijil / Fix account limits redirection for non migrated/non hub enabled countries

### DIFF
--- a/packages/hooks/src/__tests__/useAccountSettingsRedirect.spec.ts
+++ b/packages/hooks/src/__tests__/useAccountSettingsRedirect.spec.ts
@@ -166,11 +166,11 @@ describe('useAccountSettingsRedirect', () => {
             isHubRedirectionEnabled: true,
         });
 
-        const { result } = renderHook(() => useAccountSettingsRedirect('trading-assessment'));
+        const { result } = renderHook(() => useAccountSettingsRedirect('account-limits'));
 
         // Both URLs should contain the custom redirect_to value
         const expectedUrl =
-            'https://staging-hub.deriv.com/accounts/redirect?action=redirect_to&redirect_to=trading-assessment&account=demo';
+            'https://staging-hub.deriv.com/accounts/redirect?action=redirect_to&redirect_to=account-limits&account=demo';
 
         expect(result.current.redirect_url).toBe(expectedUrl);
         expect(result.current.mobile_redirect_url).toBe(expectedUrl);
@@ -187,10 +187,27 @@ describe('useAccountSettingsRedirect', () => {
             isHubRedirectionEnabled: false,
         });
 
-        const { result } = renderHook(() => useAccountSettingsRedirect('custom-page'));
+        const { result } = renderHook(() => useAccountSettingsRedirect('home'));
 
-        // Should still return the default routes regardless of the redirect_to parameter
         expect(result.current.redirect_url).toBe(routes.personal_details);
+        expect(result.current.mobile_redirect_url).toBe(routes.account);
+    });
+
+    it('should map account-limits redirect_to to routes.account_limits when hub redirection is disabled', () => {
+        (useStore as jest.Mock).mockReturnValue({
+            client: {
+                has_wallet: false,
+            },
+        });
+
+        (useIsHubRedirectionEnabled as jest.Mock).mockReturnValue({
+            isHubRedirectionEnabled: false,
+        });
+
+        const { result } = renderHook(() => useAccountSettingsRedirect('account-limits'));
+
+        // Should map to account_limits route when hub redirection is disabled
+        expect(result.current.redirect_url).toBe(routes.account_limits);
         expect(result.current.mobile_redirect_url).toBe(routes.account);
     });
 });

--- a/packages/hooks/src/useAccountSettingsRedirect.ts
+++ b/packages/hooks/src/useAccountSettingsRedirect.ts
@@ -3,7 +3,10 @@ import { useStore } from '@deriv/stores';
 
 import useIsHubRedirectionEnabled from './useIsHubRedirectionEnabled';
 
-export const useAccountSettingsRedirect = (redirect_to = 'home') => {
+// Define allowed redirect destinations as a type-safe enum
+export type RedirectDestination = 'home' | 'account-limits';
+
+export const useAccountSettingsRedirect = (redirect_to: RedirectDestination = 'home') => {
     const { client } = useStore();
     const { has_wallet } = client;
     const { isHubRedirectionEnabled } = useIsHubRedirectionEnabled();
@@ -22,7 +25,16 @@ export const useAccountSettingsRedirect = (redirect_to = 'home') => {
         redirect_url = `${base_url}/accounts/redirect?action=redirect_to&redirect_to=${redirect_to}&account=${account_type}`;
         mobile_redirect_url = `${base_url}/accounts/redirect?action=redirect_to&redirect_to=${redirect_to}&account=${account_type}`;
     } else {
-        redirect_url = routes.personal_details;
+        // Map redirect_to values to specific routes when not using hub redirection
+        switch (redirect_to) {
+            case 'account-limits':
+                redirect_url = routes.account_limits;
+                break;
+            case 'home':
+            default:
+                redirect_url = routes.personal_details;
+                break;
+        }
         mobile_redirect_url = routes.account;
     }
 


### PR DESCRIPTION
## Changes:

Clicking on the Account Limits icon ( bottom right next to language icon ) in the Trader's Hub page for non migrated/non hub enabled users redirects to the Account Limits page instead of Personal Details page.
