### PR TITLE
[COJ] codex/self-exclusion-hyphen

### DIFF
--- a/packages/account/src/Constants/routes-config.tsx
+++ b/packages/account/src/Constants/routes-config.tsx
@@ -193,7 +193,7 @@ const initRoutesConfig = () => [
                     {
                         path: routes.self_exclusion,
                         component: SelfExclusion,
-                        getTitle: () => localize('Self exclusion'),
+                        getTitle: () => localize('Self-exclusion'),
                     },
                     {
                         path: routes.account_limits,

--- a/packages/core/src/App/Constants/routes-config.js
+++ b/packages/core/src/App/Constants/routes-config.js
@@ -210,7 +210,7 @@ const getModules = () => {
                         {
                             path: routes.self_exclusion,
                             component: Account,
-                            getTitle: () => localize('Self exclusion'),
+                            getTitle: () => localize('Self-exclusion'),
                         },
                         {
                             path: routes.account_limits,


### PR DESCRIPTION
## Summary
- fix Self-exclusion label in account settings side menu

## Testing
- `npm run test` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_683fbe4ac5f4832d84ec5babed4accab