### PR TITLE
Mayuran / GRWT-6330 / Expiry date wrong date in V2

### DIFF
--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
@@ -55,7 +55,7 @@ const Duration = observer(({ is_minimized }: TTradeParametersProps) => {
     const { server_time } = common;
 
     useEffect(() => {
-        if (expiry_epoch && duration_unit !== 'd') {
+        if (expiry_epoch && duration_unit !== 'd' && !saved_expiry_date_v2) {
             // Set expiry time to end of day
             setExpiryTimeString('23:59:59');
 


### PR DESCRIPTION
## Changes:

Expiry date wrong date in DTrader V2
