### PR TITLE
Fix undefined CTrader landing company check

### DIFF
--- a/packages/core/src/Stores/traders-hub-store.js
+++ b/packages/core/src/Stores/traders-hub-store.js
@@ -627,7 +627,7 @@ export default class TradersHubStore extends BaseStore {
             this.CFDs_restricted_countries ||
             this.financial_restricted_countries ||
             (this.root_store.client.is_logged_in &&
-                this.root_store.client.landing_companies.ctrader.all.standard === 'none')
+                this.root_store.client.landing_companies?.ctrader?.all?.standard === 'none')
         ) {
             this.available_ctrader_accounts = [];
             return;


### PR DESCRIPTION
## Summary
- avoid crash when landing_companies.ctrader is missing

## Testing
- `npm run test` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a63691300832dab4fd35a6db86c01