### PR TITLE
[DTrader] Farabi/grwt-6248/remove-mobile-tutorial-video-sounds 

### DIFF
--- a/packages/trader/src/AppV2/Components/Guide/guide-description-modal.tsx
+++ b/packages/trader/src/AppV2/Components/Guide/guide-description-modal.tsx
@@ -110,6 +110,8 @@ const GuideDescriptionModal = ({
                     increased_drag_area
                     src={video_src}
                     onModalClose={toggleVideoPlayer}
+                    muted={true}
+                    hide_volume_control={true}
                 />
             </PortalModal>
         </React.Fragment>


### PR DESCRIPTION
This pull request includes a small change to the `GuideDescriptionModal` component in `guide-description-modal.tsx`. The change ensures that the video player is muted by default and hides the volume control.