### PR TITLE
[DTrader] Farabi/grwt-6239/random-strings-on-market-search

### DIFF
--- a/packages/trader/src/AppV2/Components/SymbolNotFound/symbol-not-found.tsx
+++ b/packages/trader/src/AppV2/Components/SymbolNotFound/symbol-not-found.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@deriv-com/quill-ui';
-import { Localize } from '@deriv/translations';
+import { Localize, localize } from '@deriv/translations';
 import React from 'react';
 
 const SymbolNotFound = ({ searchTerm }: { searchTerm?: string }) => {
@@ -7,7 +7,10 @@ const SymbolNotFound = ({ searchTerm }: { searchTerm?: string }) => {
         <div className='symbol-not-found__container'>
             <div className='symbol-not-found__content'>
                 <Text size='lg' bold color='quill-typography__color--subtle'>
-                    <Localize i18n_default_text='No results for {{searchTerm}}' values={{ searchTerm }} />
+                    {localize('No results for {{searchTerm}}', {
+                        searchTerm,
+                        interpolation: { escapeValue: false },
+                    })}
                 </Text>
                 <Text size='sm' color='quill-typography__color--subtle'>
                     <Localize i18n_default_text='Try searching for something else.' />


### PR DESCRIPTION
This pull request updates the `SymbolNotFound` component to improve localization handling by switching from the `Localize` component to the `localize` function for dynamic text.

Localization improvements:

* [`packages/trader/src/AppV2/Components/SymbolNotFound/symbol-not-found.tsx`](diffhunk://#diff-1f50a19cb9d8748b2b22fba707fae7c61d359040d4969e9fbc08127a13c173fcL2-R13): Replaced the `Localize` component with the `localize` function for the dynamic "No results for {{searchTerm}}" message. This allows for additional options, such as disabling HTML escaping via `interpolation: { escapeValue: false }`.