### PR TITLE
Fix useEffect import in cashier routes

### DIFF
--- a/packages/cashier/src/containers/routes/binary-routes.tsx
+++ b/packages/cashier/src/containers/routes/binary-routes.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Switch } from 'react-router-dom';
 
 import { Loading } from '@deriv/components';


### PR DESCRIPTION
## Summary
- add missing `useEffect` import in BinaryRoutes component

## Testing
- `npm test` *(fails: stylelint: not found)*

------
https://chatgpt.com/codex/tasks/task_b_687637d0f3e8832d92e14d1a51f45dbd