### PR TITLE
Add TrackJS/Datadog logs for wallet migration issues

### DIFF
--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -34,6 +34,7 @@ import {
 import { getLanguage, getRedirectionLanguage, localize } from '@deriv/translations';
 import { Analytics } from '@deriv-com/analytics';
 import { CountryUtils, URLConstants } from '@deriv-com/utils';
+import { logError } from '@deriv/utils';
 
 import { requestLogout, WS } from 'Services';
 import BinarySocketGeneral from 'Services/socket-general';
@@ -2934,6 +2935,9 @@ export default class ClientStore extends BaseStore {
 
     setWalletMigrationState(state) {
         this.wallet_migration_state = state;
+        if (state === 'failed') {
+            logError('Wallet migration failed', { loginid: this.loginid });
+        }
     }
 
     setIsWalletMigrationRequestIsInProgress(value) {
@@ -2945,8 +2949,10 @@ export default class ClientStore extends BaseStore {
             const response = await WS.authorized.getWalletMigrationState();
             if (response?.wallet_migration?.state) this.setWalletMigrationState(response?.wallet_migration?.state);
         } catch (error) {
-            // eslint-disable-next-line no-console
-            console.log(`Something wrong: code = ${error?.error?.code}, message = ${error?.error?.message}`);
+            logError('getWalletMigrationState error', {
+                code: error?.error?.code,
+                message: error?.error?.message,
+            });
         }
     }
 
@@ -2956,8 +2962,10 @@ export default class ClientStore extends BaseStore {
             await WS.authorized.startWalletMigration();
             await this.getWalletMigrationState();
         } catch (error) {
-            // eslint-disable-next-line no-console
-            console.log(`Something wrong: code = ${error?.error?.code}, message = ${error?.error?.message}`);
+            logError('startWalletMigration error', {
+                code: error?.error?.code,
+                message: error?.error?.message,
+            });
         } finally {
             this.setIsWalletMigrationRequestIsInProgress(false);
         }
@@ -2969,8 +2977,10 @@ export default class ClientStore extends BaseStore {
             await WS.authorized.resetWalletMigration();
             this.getWalletMigrationState();
         } catch (error) {
-            // eslint-disable-next-line no-console
-            console.log(`Something wrong: code = ${error?.error?.code}, message = ${error?.error?.message}`);
+            logError('resetWalletMigration error', {
+                code: error?.error?.code,
+                message: error?.error?.message,
+            });
         } finally {
             this.setIsWalletMigrationRequestIsInProgress(false);
         }

--- a/packages/core/src/Stores/traders-hub-store.js
+++ b/packages/core/src/Stores/traders-hub-store.js
@@ -12,6 +12,7 @@ import {
 import { localize } from '@deriv/translations';
 import BaseStore from './base-store';
 import { isEuCountry } from '_common/utility';
+import { logError } from '@deriv/utils';
 
 export default class TradersHubStore extends BaseStore {
     available_platforms = [];
@@ -913,6 +914,9 @@ export default class TradersHubStore extends BaseStore {
 
     setWalletsMigrationFailedPopup(value) {
         this.is_wallet_migration_failed = value;
+        if (value) {
+            logError('Wallets migration failed popup', { loginid: this.root_store.client.loginid });
+        }
     }
 
     cleanup() {

--- a/packages/utils/src/__tests__/logging.spec.ts
+++ b/packages/utils/src/__tests__/logging.spec.ts
@@ -1,0 +1,45 @@
+import { logError } from '../logging';
+import { datadogRum } from '@datadog/browser-rum';
+
+jest.mock('@datadog/browser-rum', () => ({
+    datadogRum: {
+        addError: jest.fn(),
+    },
+}));
+
+describe('logError', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (window as any).TrackJS = undefined;
+        (window as any).DD_RUM = undefined;
+    });
+
+    it('should log to TrackJS and datadog when available', () => {
+        const trackSpy = jest.fn();
+        (window as any).TrackJS = { track: trackSpy };
+        (datadogRum.addError as jest.Mock).mockImplementation(() => {});
+
+        logError('test message', { foo: 'bar' });
+
+        expect(trackSpy).toHaveBeenCalledWith({ message: 'test message', foo: 'bar' });
+        expect(datadogRum.addError).toHaveBeenCalledWith('test message', { extra: { foo: 'bar' } });
+    });
+
+    it('should fallback to window.DD_RUM when datadogRum is unavailable', () => {
+        const ddRumAddError = jest.fn();
+        // @ts-ignore - modify mocked module
+        datadogRum.addError = undefined;
+        (window as any).DD_RUM = { addError: ddRumAddError };
+
+        logError('another message');
+
+        expect(ddRumAddError).toHaveBeenCalledWith('another message', { extra: {} });
+    });
+
+    it('should not throw if no logging clients are available', () => {
+        // @ts-ignore - modify mocked module
+        datadogRum.addError = undefined;
+
+        expect(() => logError('no clients')).not.toThrow();
+    });
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -17,3 +17,4 @@ export { default as isTmbEnabled } from './isTmbEnabled';
 export * from './parse-url';
 export * from './moment';
 export * from './files';
+export * from './logging';

--- a/packages/utils/src/logging.ts
+++ b/packages/utils/src/logging.ts
@@ -1,0 +1,16 @@
+import { datadogRum } from '@datadog/browser-rum';
+
+export type TLogData = Record<string, unknown>;
+
+export const logError = (message: string, data: TLogData = {}): void => {
+    const payload = { message, ...data };
+    if (window.TrackJS?.track) {
+        window.TrackJS.track(payload);
+    }
+    if (typeof datadogRum?.addError === 'function') {
+        datadogRum.addError(message, { extra: data });
+    } else if (window.DD_RUM && typeof (window.DD_RUM as any).addError === 'function') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window.DD_RUM as any).addError(message, { extra: data });
+    }
+};


### PR DESCRIPTION
## Summary
- add utility for logging to TrackJS and Datadog
- log wallet migration failures in client store
- log opening of wallet migration failure popup
- add tests for logging utility

## Testing
- `npm test` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_6874e5a06928832d868bf135e5d42a5f