### PR TITLE
Fix cashier endless loading when hub redirect data missing

### DIFF
--- a/packages/cashier/src/containers/cashier/cashier.tsx
+++ b/packages/cashier/src/containers/cashier/cashier.tsx
@@ -285,7 +285,7 @@ const Cashier = observer(({ history, location, routes: routes_config }: TCashier
 
     if (
         is_cashier_loading ||
-        (has_wallet && (!isHubRedirectionLoaded || isHubRedirectionEnabled))
+        (has_wallet && isHubRedirectionLoaded && isHubRedirectionEnabled)
     ) {
         return <Loading is_fullscreen />;
     }

--- a/packages/cashier/src/containers/cashier/cashier.tsx
+++ b/packages/cashier/src/containers/cashier/cashier.tsx
@@ -283,7 +283,10 @@ const Cashier = observer(({ history, location, routes: routes_config }: TCashier
         is_payment_agent_transfer_checking ||
         is_p2p_loading;
 
-    if (is_cashier_loading || has_wallet) {
+    if (
+        is_cashier_loading ||
+        (has_wallet && (!isHubRedirectionLoaded || isHubRedirectionEnabled))
+    ) {
         return <Loading is_fullscreen />;
     }
 


### PR DESCRIPTION
## Summary
- fallback to classic cashier when hub redirection data hasn't loaded or redirection is enabled
