### PR TITLE
Improve build performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,19 +63,23 @@ Before running or contribute to this project, you need to have the setup of the 
 > - Find and copy nx-cloud accessToken
 > - Make a copy of `nx-cloud.env.example` from root directory of the project and name it `nx-cloud.env` and replace the `<token>` with provided token.
 
-3.  **Enter project directory**
+3.  **Enable Nx Cloud caching (recommended)**
+
+    Create a `nx-cloud.env` file with your `NX_CLOUD_ACCESS_TOKEN`. This enables remote caching so repeated builds can reuse previous outputs.
+
+4.  **Enter project directory**
 
     ```sh
     cd deriv-app
     ```
 
-4.  **Install your dependencies:**
+5.  **Install your dependencies:**
 
     ```sh
     npm run bootstrap
     ```
 
-5.  **Build packages:**
+6.  **Build packages:**
 
     ```sh
     npm run build:all

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "scripts": {
         "analyze:build": "nx run-many --target=analyze:build",
         "analyze:stats": "nx run-many --target=analyze:stats",
-        "build:all": "nx build @deriv/components --skip-nx-cache && nx build @deriv/account  --skip-nx-cache && nx build @deriv/bot-web-ui --skip-nx-cache && nx build @deriv/trader --skip-nx-cache && nx run-many --target=build",
+        "build:all": "nx run-many --target=build --all --parallel",
         "build:one": "f () { nx build @deriv/$1 $2 ;}; f",
         "build:since": "nx affected --target=build",
         "test:eslint-all": "nx run-many --target=test:eslint",


### PR DESCRIPTION
## Summary
- streamline `build:all` using Nx parallelization and caching
- document how to use Nx Cloud cache for faster builds

