### PR TITLE
Fix cashier endless loading when hub redirect data missing

### DIFF
--- a/packages/cashier/src/containers/cashier/cashier.tsx
+++ b/packages/cashier/src/containers/cashier/cashier.tsx
@@ -283,7 +283,10 @@ const Cashier = observer(({ history, location, routes: routes_config }: TCashier
         is_payment_agent_transfer_checking ||
         is_p2p_loading;
 
-    if (is_cashier_loading || has_wallet) {
+    if (
+        is_cashier_loading ||
+        (has_wallet && isHubRedirectionLoaded && isHubRedirectionEnabled)
+    ) {
         return <Loading is_fullscreen />;
     }
 

--- a/packages/cfd/src/init-store.js
+++ b/packages/cfd/src/init-store.js
@@ -3,7 +3,7 @@ import RootStore from './Stores';
 import { setWebsocket } from '@deriv/shared';
 import ServerTime from '_common/base/server_time';
 
-configure({ enforceActions: 'observed' });
+configure({ enforceActions: 'observed', isolateGlobalState: true });
 
 let root_store;
 

--- a/packages/core/src/App/initStore.js
+++ b/packages/core/src/App/initStore.js
@@ -3,7 +3,7 @@ import { excludeParamsFromUrlQuery, startPerformanceEventTimer } from '@deriv/sh
 import NetworkMonitor from 'Services/network-monitor';
 import RootStore from 'Stores';
 
-configure({ enforceActions: 'observed' });
+configure({ enforceActions: 'observed', isolateGlobalState: true });
 
 const setStorageEvents = root_store => {
     window.addEventListener('storage', evt => {

--- a/packages/trader/src/App/init-store.ts
+++ b/packages/trader/src/App/init-store.ts
@@ -5,7 +5,7 @@ import { TCoreStores } from '@deriv/stores/types';
 import type { TWebSocket } from 'Types';
 import RootStore from '../Stores';
 
-configure({ enforceActions: 'observed' });
+configure({ enforceActions: 'observed', isolateGlobalState: true });
 
 let root_store: TCoreStores;
 


### PR DESCRIPTION
## Summary
- fallback to classic cashier when hub redirection data hasn't loaded or redirection is enabled
- configure MobX to isolate global state so multiple versions don't conflict

## Testing
- `npx jest packages/cashier --runTestsByPath` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_b_6877c2db0408832d861333d59ea997c7