### PR TITLE
Fix cashier loading due to wallet redirection

### DIFF
--- a/packages/cashier/src/containers/cashier/cashier.tsx
+++ b/packages/cashier/src/containers/cashier/cashier.tsx
@@ -260,6 +260,12 @@ const Cashier = observer(({ history, location, routes: routes_config }: TCashier
     ]);
 
     useEffect(() => {
+        console.log('Cashier: checking wallet redirection', {
+            has_wallet,
+            isHubRedirectionLoaded,
+            isHubRedirectionEnabled,
+        });
+
         if (has_wallet && isHubRedirectionLoaded && isHubRedirectionEnabled) {
             const redirectUrl = window.location.hostname.includes('staging')
                 ? STAGING_REDIRECT_URL
@@ -272,7 +278,9 @@ const Cashier = observer(({ history, location, routes: routes_config }: TCashier
             const account_currency =
                 client_accounts?.[active_wallet_loginid || '']?.currency || url_params.get('account');
 
-            window.location.href = `${redirectUrl}/redirect?action=redirect_to&redirect_to=wallet_home${account_currency ? `&account=${account_currency}` : ''}`;
+            const redirect_path = `${redirectUrl}/redirect?action=redirect_to&redirect_to=wallet_home${account_currency ? `&account=${account_currency}` : ''}`;
+            console.log('Cashier: redirecting to', redirect_path);
+            window.location.href = redirect_path;
         }
     }, [has_wallet, isHubRedirectionEnabled, isHubRedirectionLoaded]);
 
@@ -284,6 +292,10 @@ const Cashier = observer(({ history, location, routes: routes_config }: TCashier
         is_p2p_loading;
 
     if (is_cashier_loading || has_wallet) {
+        console.log('Cashier: showing loading screen', {
+            is_cashier_loading,
+            has_wallet,
+        });
         return <Loading is_fullscreen />;
     }
 

--- a/packages/cashier/src/containers/routes/binary-routes.tsx
+++ b/packages/cashier/src/containers/routes/binary-routes.tsx
@@ -32,6 +32,15 @@ const BinaryRoutes = (props: TBinaryRoutesProps) => {
     const STAGING_REDIRECT_URL = `https://staging-hub.${getDomainUrl()}/tradershub`;
 
     useEffect(() => {
+        console.log('BinaryRoutes: checking redirection', {
+            isHubRedirectionEnabled,
+            has_wallet,
+            is_logging_out,
+            is_logged_in,
+            prevent_redirect_to_hub,
+            is_client_store_initialized,
+        });
+
         if (
             isHubRedirectionEnabled &&
             has_wallet &&
@@ -51,7 +60,9 @@ const BinaryRoutes = (props: TBinaryRoutesProps) => {
             const url_params = new URLSearchParams(url_query_string);
             const account_currency = window.sessionStorage.getItem('account') || url_params.get('account');
             localStorage.setItem('wallet_redirect_done', true);
-            window.location.href = `${redirectUrl}/redirect?action=redirect_to&redirect_to=wallet${account_currency ? `&account=${account_currency}` : ''}`;
+            const redirect_path = `${redirectUrl}/redirect?action=redirect_to&redirect_to=wallet${account_currency ? `&account=${account_currency}` : ''}`;
+            console.log('BinaryRoutes: redirecting to', redirect_path);
+            window.location.href = redirect_path;
         }
 
         const shouldStayInDerivApp = !isHubRedirectionEnabled || !has_wallet || prevent_redirect_to_hub;
@@ -69,7 +80,8 @@ const BinaryRoutes = (props: TBinaryRoutesProps) => {
         is_client_store_initialized,
     ]);
 
-    if (isHubRedirectionEnabled) {
+    if (isHubRedirectionEnabled && has_wallet) {
+        console.log('BinaryRoutes: displaying loading screen while redirecting');
         return <Loading is_fullscreen />;
     }
 


### PR DESCRIPTION
## Summary
- avoid infinite loader when hub redirection is enabled but user has no wallet
- add console logs for wallet redirection flows

## Testing
- `npm test` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_68786e1aae70832d93ee43003091180d