### PR TITLE
Aizad/WEBREL-4736/Cashier lock message briefly appears when switching from demo to real account

### DIFF
--- a/packages/cashier/src/components/cashier-locked-checker/cashier-locked-checker.tsx
+++ b/packages/cashier/src/components/cashier-locked-checker/cashier-locked-checker.tsx
@@ -10,7 +10,7 @@ import PageContainer from '../page-container';
 
 const CashierLockedChecker: React.FC<React.PropsWithChildren<unknown>> = observer(({ children }) => {
     const { client } = useStore();
-    const { is_virtual, is_switching } = client;
+    const { is_virtual } = client;
     const currency_config = useCurrentCurrencyConfig();
     const is_cashier_locked = useCashierLocked();
     const is_system_maintenance = useIsSystemMaintenance();
@@ -35,7 +35,7 @@ const CashierLockedChecker: React.FC<React.PropsWithChildren<unknown>> = observe
         }
     }
 
-    if (is_cashier_locked && !is_switching)
+    if (is_cashier_locked)
         return (
             <PageContainer hide_breadcrumb right={<React.Fragment />}>
                 <CashierLocked />

--- a/packages/cashier/src/components/cashier-locked-checker/cashier-locked-checker.tsx
+++ b/packages/cashier/src/components/cashier-locked-checker/cashier-locked-checker.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+
 import { useCashierLocked, useCurrentCurrencyConfig, useDepositLocked, useIsSystemMaintenance } from '@deriv/hooks';
 import { observer, useStore } from '@deriv/stores';
+
 import { useCashierStore } from '../../stores/useCashierStores';
 import { Virtual } from '../cashier-container';
 import CashierLocked from '../cashier-locked';
@@ -8,7 +10,7 @@ import PageContainer from '../page-container';
 
 const CashierLockedChecker: React.FC<React.PropsWithChildren<unknown>> = observer(({ children }) => {
     const { client } = useStore();
-    const { is_virtual } = client;
+    const { is_virtual, is_switching } = client;
     const currency_config = useCurrentCurrencyConfig();
     const is_cashier_locked = useCashierLocked();
     const is_system_maintenance = useIsSystemMaintenance();
@@ -33,7 +35,7 @@ const CashierLockedChecker: React.FC<React.PropsWithChildren<unknown>> = observe
         }
     }
 
-    if (is_cashier_locked)
+    if (is_cashier_locked && !is_switching)
         return (
             <PageContainer hide_breadcrumb right={<React.Fragment />}>
                 <CashierLocked />

--- a/packages/cashier/src/components/page-container/page-container.tsx
+++ b/packages/cashier/src/components/page-container/page-container.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import classNames from 'classnames';
+
 import { Loading, ThemedScrollbars } from '@deriv/components';
 import { observer, useStore } from '@deriv/stores';
 import { useDevice } from '@deriv-com/ui';
+
 import './page-container.scss';
 
 const CashierBreadcrumb = React.lazy(
@@ -22,8 +24,8 @@ const PageContainer: React.FC<React.PropsWithChildren<TProps>> = observer(
             common: { is_from_outside_cashier },
         } = useStore();
         const { isDesktop } = useDevice();
-        const { is_authorize } = client;
-        const is_loading = !is_authorize;
+        const { is_authorize, is_switching } = client;
+        const is_loading = !is_authorize || is_switching;
 
         return (
             <div


### PR DESCRIPTION
## Changes:

Added `is_switching` check inside cashier-locked-provider to ensure account is fully switch before showing content

### Screenshots:

https://github.com/user-attachments/assets/c2fc7eed-3c33-4fef-8857-fd8ebd8f312b

https://github.com/user-attachments/assets/75d61b6a-d88a-4fc5-a301-ef3c0496f6c7



