### PR TITLE
feat(core): ensure output hash varies per build

### DIFF
--- a/packages/core/build/config.js
+++ b/packages/core/build/config.js
@@ -308,8 +308,8 @@ const htmlPreloadConfig = () => ({
 });
 
 const cssConfig = () => ({
-    filename: 'css/core.[name].[contenthash].main.css',
-    chunkFilename: 'css/core.chunk.[name].[contenthash].css',
+    filename: 'css/core.[name].[fullhash].main.css',
+    chunkFilename: 'css/core.chunk.[name].[fullhash].css',
 });
 
 const stylelintConfig = () => ({

--- a/packages/core/build/webpack.config.js
+++ b/packages/core/build/webpack.config.js
@@ -70,7 +70,8 @@ module.exports = function (env) {
             },
         },
         output: {
-            filename: 'js/core.[name].[contenthash].js',
+            filename: 'js/core.[name].[fullhash].js',
+            chunkFilename: 'js/core.chunk.[name].[fullhash].js',
             publicPath: base,
             path: path.resolve(__dirname, '../dist'),
         },


### PR DESCRIPTION
## Summary
- use webpack fullhash for core CSS and JS bundles so filenames change on every release

## Testing
- `npm test` *(failed: hung after eslint tasks)*


------
https://chatgpt.com/codex/tasks/task_b_689076300fd8832d9a5b72eb7223f5e9