### PR TITLE
fix: remove extra line on get started modal

### DIFF
--- a/packages/cfd/src/Containers/account-nakala-modal/account-nakala-modal.scss
+++ b/packages/cfd/src/Containers/account-nakala-modal/account-nakala-modal.scss
@@ -64,7 +64,9 @@
         gap: 1.6rem;
         margin: 10px 5px;
         position: relative;
+    }
 
+    &__steps--with-line {
         &:before {
             content: '';
             position: absolute;

--- a/packages/cfd/src/Containers/account-nakala-modal/account-nakala-modal.tsx
+++ b/packages/cfd/src/Containers/account-nakala-modal/account-nakala-modal.tsx
@@ -148,7 +148,7 @@ export const CFDDerivNakalaLinkAccount = observer((props: TCFDDerivNakalaLinkAcc
                     </div>
                 )}
 
-                <div className='cfd-nakala-modal__steps'>
+                <div className='cfd-nakala-modal__steps cfd-nakala-modal__steps--with-line'>
                     <div className='cfd-nakala-modal__step'>
                         <div className='cfd-nakala-modal__step-number'>
                             <Text weight='bold' color='colored-background'>


### PR DESCRIPTION
This pull request introduces a minor UI improvement to the `CFDDerivNakalaLinkAccount` modal by updating the visual styling of the steps indicator. The main change is the addition of a new CSS class that adds a line before the steps, enhancing the user interface.

**UI Enhancement:**

* Added the `cfd-nakala-modal__steps--with-line` CSS class to the steps container in `account-nakala-modal.tsx` to visually separate the steps with a line.
* Defined the new `cfd-nakala-modal__steps--with-line` class in the SCSS file to implement the line styling using the `:before` pseudo-element.