### PR TITLE
Ahmed/fix  add prod url for nakala

### DIFF
--- a/packages/hooks/src/useIsEnabledNakala.ts
+++ b/packages/hooks/src/useIsEnabledNakala.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 
 import useGrowthbookGetFeatureValue from './useGrowthbookGetFeatureValue';
 
-const NAKALA_INFO_ENDPOINT = {
+const NAKALA_INFO_BASEURL = {
     PRODUCTION: `https://api-gateway.deriv.com`,
     STAGING: `https://staging-api-gateway.deriv.com`,
 };
@@ -43,7 +43,7 @@ const useIsEnabledNakala = (accounts: any[]) => {
     const getNakalaServerInfo = async () => {
         try {
             const isProduction = process.env.NODE_ENV === 'production';
-            const apiUrl = isProduction ? NAKALA_INFO_ENDPOINT.PRODUCTION : NAKALA_INFO_ENDPOINT.STAGING;
+            const apiUrl = isProduction ? NAKALA_INFO_BASEURL.PRODUCTION : NAKALA_INFO_BASEURL.STAGING;
 
             const response = await axios.get(`${apiUrl}/nakala/v1/nakala-servers?mt5_login_id=${loginId}`);
             setNakalaServerInfo(response.data?.server_name);

--- a/packages/hooks/src/useIsEnabledNakala.ts
+++ b/packages/hooks/src/useIsEnabledNakala.ts
@@ -4,6 +4,11 @@ import axios from 'axios';
 
 import useGrowthbookGetFeatureValue from './useGrowthbookGetFeatureValue';
 
+const NAKALA_INFO_ENDPOINT = {
+    PRODUCTION: `https://api-gateway.deriv.com`,
+    STAGING: `https://staging-api-gateway.deriv.com`,
+};
+
 const useIsEnabledNakala = (accounts: any[]) => {
     const getMT5Account = (accounts: any[]) => {
         if (!accounts?.length) return null;
@@ -37,9 +42,10 @@ const useIsEnabledNakala = (accounts: any[]) => {
 
     const getNakalaServerInfo = async () => {
         try {
-            const response = await axios.get(
-                `https://staging-api-gateway.deriv.com/nakala/v1/nakala-servers?mt5_login_id=${loginId}`
-            );
+            const isProduction = process.env.NODE_ENV === 'production';
+            const apiUrl = isProduction ? NAKALA_INFO_ENDPOINT.PRODUCTION : NAKALA_INFO_ENDPOINT.STAGING;
+
+            const response = await axios.get(`${apiUrl}/nakala/v1/nakala-servers?mt5_login_id=${loginId}`);
             setNakalaServerInfo(response.data?.server_name);
         } catch (error) {
             // eslint-disable-next-line no-console


### PR DESCRIPTION
This pull request updates the `useIsEnabledNakala` hook to use environment-based API endpoints for fetching Nakala server information. The main improvement is to ensure that the correct API base URL is used depending on whether the application is running in production or staging.

**Environment-based API configuration:**

* Added a `NAKALA_INFO_BASEURL` constant to define the API base URLs for production and staging environments in `useIsEnabledNakala.ts`.
* Updated the Nakala server info fetch logic to dynamically select the API endpoint based on the `NODE_ENV` environment variable, ensuring requests go to the appropriate backend.