### PR TITLE
DSEC-63673: Fix GitHub Actions workflow permission issues

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -49,6 +49,8 @@ jobs:
     name: Coveralls Finished
     needs: [test]
     runs-on: Runner_16cores_Deriv-app
+    permissions:
+      contents: read
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949

--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -73,6 +73,8 @@ jobs:
     environment: Production
     if: failure()
     needs: [build_test_and_publish]
+    permissions:
+      contents: read
     steps:
       - name: Send Slack Notification
         uses: "deriv-com/shared-actions/.github/actions/send_slack_notification@master"
@@ -86,6 +88,8 @@ jobs:
     environment: Production
     if: success()
     needs: [build_test_and_publish]
+    permissions:
+      contents: read
     steps:
       - name: Send Slack Notification
         uses: "deriv-com/shared-actions/.github/actions/send_slack_notification@master"
@@ -98,6 +102,9 @@ jobs:
     runs-on: Runner_8cores_Deriv-app
     environment: Production
     needs: [build_test_and_publish]
+    permissions:
+      contents: read
+      actions: read
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION


This branch addresses permission issues in GitHub Actions workflows:

- Added missing permissions for Slack notification jobs in production workflow
- Added missing permissions for Coveralls Finished job

These fixes ensure proper execution of CI/CD workflows by explicitly defining required permissions for GitHub Actions jobs.