### PR TITLE
Suisin/chore: fix cfd reset password displaying again on reload

### DIFF
--- a/packages/cfd/src/Containers/cfd-reset-password-modal.tsx
+++ b/packages/cfd/src/Containers/cfd-reset-password-modal.tsx
@@ -74,6 +74,10 @@ const CFDResetPasswordModal = observer(({ platform }: TCFDResetPasswordModal) =>
         changed_password_type: '',
     });
 
+    const resetUrl = () => {
+        window.history.replaceState(null, '', window.location.pathname + window.location.search);
+    };
+
     const renderErrorBox = (error: TError) => {
         setState({
             ...state,
@@ -141,6 +145,7 @@ const CFDResetPasswordModal = observer(({ platform }: TCFDResetPasswordModal) =>
                 });
                 clearAddressBar();
             }
+            resetUrl();
             setSubmitting(false);
         });
     };


### PR DESCRIPTION
## Changes:

Fix cfd reset password modal keeps displaying on reload after finish reseting password

### Screenshots:

Please provide some screenshots of the change.
