### PR TITLE
fix: isolate MobX global state

### DIFF
--- a/packages/cfd/src/init-store.js
+++ b/packages/cfd/src/init-store.js
@@ -3,7 +3,7 @@ import RootStore from './Stores';
 import { setWebsocket } from '@deriv/shared';
 import ServerTime from '_common/base/server_time';
 
-configure({ enforceActions: 'observed' });
+configure({ enforceActions: 'observed', isolateGlobalState: true });
 
 let root_store;
 

--- a/packages/core/src/App/initStore.js
+++ b/packages/core/src/App/initStore.js
@@ -3,7 +3,7 @@ import { excludeParamsFromUrlQuery, startPerformanceEventTimer } from '@deriv/sh
 import NetworkMonitor from 'Services/network-monitor';
 import RootStore from 'Stores';
 
-configure({ enforceActions: 'observed' });
+configure({ enforceActions: 'observed', isolateGlobalState: true });
 
 const setStorageEvents = root_store => {
     window.addEventListener('storage', evt => {

--- a/packages/trader/src/App/init-store.ts
+++ b/packages/trader/src/App/init-store.ts
@@ -5,7 +5,7 @@ import { TCoreStores } from '@deriv/stores/types';
 import type { TWebSocket } from 'Types';
 import RootStore from '../Stores';
 
-configure({ enforceActions: 'observed' });
+configure({ enforceActions: 'observed', isolateGlobalState: true });
 
 let root_store: TCoreStores;
 


### PR DESCRIPTION
## Summary
- configure MobX to isolate global state in core, trader, and cfd modules