### PR TITLE
Farabi/grwt-8949/contract-details-loading-infinitely

### DIFF
--- a/packages/trader/src/App/Components/Elements/ContractDrawer/__tests__/contract-drawer.spec.tsx
+++ b/packages/trader/src/App/Components/Elements/ContractDrawer/__tests__/contract-drawer.spec.tsx
@@ -90,13 +90,39 @@ describe('<ContractDrawer />', () => {
 
         expect(container).toBeEmptyDOMElement();
     });
-    it('should render PositionsCardLoader component if  contract_info.status || contract_info.is_expired are falsy', () => {
-        mocked_props.contract_info = { status: null, is_expired: 0 };
+    it('should render PositionsCardLoader component if status, isEnded, and is_sold are all falsy', () => {
+        mocked_props.contract_info = { status: null, is_expired: 0, is_sold: 0 };
         render(mockContractDrawer(mocked_props));
 
         expect(screen.getByText('Position Card Loader')).toBeInTheDocument();
         expect(screen.queryByText(contract_drawer_card)).not.toBeInTheDocument();
         expect(screen.queryByText(contract_audit)).not.toBeInTheDocument();
+    });
+    it('should render Contract Drawer card when status is null but is_expired is truthy (Multiplier expired)', () => {
+        mocked_props.contract_info = {
+            currency: 'USD',
+            exit_tick_display_value: '2021.56',
+            status: null,
+            is_expired: 1,
+            is_sold: 0,
+        };
+        render(mockContractDrawer(mocked_props));
+
+        expect(screen.getByText(contract_drawer_card)).toBeInTheDocument();
+        expect(screen.queryByText('Position Card Loader')).not.toBeInTheDocument();
+    });
+    it('should render Contract Drawer card when status is null but is_sold is truthy (Multiplier sold)', () => {
+        mocked_props.contract_info = {
+            currency: 'USD',
+            exit_tick_display_value: '2021.56',
+            status: null,
+            is_expired: 0,
+            is_sold: 1,
+        };
+        render(mockContractDrawer(mocked_props));
+
+        expect(screen.getByText(contract_drawer_card)).toBeInTheDocument();
+        expect(screen.queryByText('Position Card Loader')).not.toBeInTheDocument();
     });
     it('should render component with Contract Drawer card and Contract Audit', () => {
         mocked_props.contract_info = {
@@ -119,26 +145,26 @@ describe('<ContractDrawer />', () => {
         expect(screen.getByText(contract_drawer_card)).toBeInTheDocument();
         expect(screen.queryByText(contract_audit)).not.toBeInTheDocument();
     });
-    it('should render contract_audit if user click on Contract Drawer card on mobile', () => {
+    it('should render contract_audit if user click on Contract Drawer card on mobile', async () => {
         (useDevice as jest.Mock).mockReturnValue({ isMobile: true });
         const { rerender } = render(mockContractDrawer(mocked_props));
         expect(screen.queryByText(contract_audit)).not.toBeInTheDocument();
 
-        userEvent.click(screen.getByText('toggleContractAuditDrawer'));
+        await userEvent.click(screen.getByText('toggleContractAuditDrawer'));
         rerender(mockContractDrawer(mocked_props));
 
         expect(screen.getByText(contract_audit)).toBeInTheDocument();
     });
-    it('contract_audit appeared and then be hidden if user swiped up and then swiped down on mobile', () => {
+    it('contract_audit appeared and then be hidden if user swiped up and then swiped down on mobile', async () => {
         (useDevice as jest.Mock).mockReturnValue({ isMobile: true });
         const { rerender } = render(mockContractDrawer(mocked_props));
         expect(screen.queryByText(contract_audit)).not.toBeInTheDocument();
 
-        userEvent.click(screen.getByText('onSwipedUp'));
+        await userEvent.click(screen.getByText('onSwipedUp'));
         rerender(mockContractDrawer(mocked_props));
         expect(screen.getByText(contract_audit)).toBeInTheDocument();
 
-        userEvent.click(screen.getByText('onSwipedDown'));
+        await userEvent.click(screen.getByText('onSwipedDown'));
         rerender(mockContractDrawer(mocked_props));
         expect(screen.queryByText(contract_audit)).not.toBeInTheDocument();
     });

--- a/packages/trader/src/App/Components/Elements/ContractDrawer/contract-drawer.tsx
+++ b/packages/trader/src/App/Components/Elements/ContractDrawer/contract-drawer.tsx
@@ -1,24 +1,28 @@
-import classNames from 'classnames';
 import React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { CSSTransition } from 'react-transition-group';
+import classNames from 'classnames';
+
 import { Div100vhContainer } from '@deriv/components';
 import {
-    isEmptyObject,
     getDurationPeriod,
     getDurationTime,
     getDurationUnitText,
     getEndTime,
+    isEmptyObject,
+    isEnded,
     mobileOSDetect,
-    TContractStore,
     TContractInfo,
+    TContractStore,
 } from '@deriv/shared';
-import ContractAudit from 'App/Components/Elements/ContractAudit';
-import { PositionsCardLoader } from 'App/Components/Elements/ContentLoader';
-import ContractDrawerCard from './contract-drawer-card';
-import { SwipeableContractAudit } from './swipeable-components';
 import { observer, useStore } from '@deriv/stores';
 import { useDevice } from '@deriv-com/ui';
+
+import { PositionsCardLoader } from 'App/Components/Elements/ContentLoader';
+import ContractAudit from 'App/Components/Elements/ContractAudit';
+
+import ContractDrawerCard from './contract-drawer-card';
+import { SwipeableContractAudit } from './swipeable-components';
 
 type TContractDrawerCardProps = React.ComponentProps<typeof ContractDrawerCard>;
 type TContractDrawerProps = RouteComponentProps & {
@@ -90,8 +94,9 @@ const ContractDrawer = observer(
 
         if (isEmptyObject(contract_info)) return null;
 
-        // For non-binary contract, the status is always null, so we check for is_expired in contract_info
-        const fallback_result = contract_info.status || contract_info.is_expired;
+        // For non-binary contracts (e.g. Multipliers), status is always null,
+        // Check isEnded and is_sold to determine if data is ready to display.
+        const fallback_result = contract_info.status || isEnded(contract_info) || contract_info.is_sold;
 
         const body_content = fallback_result ? (
             <React.Fragment>


### PR DESCRIPTION
This pull request improves the logic and test coverage for the `ContractDrawer` component, particularly in how it determines when to show the contract card versus the loader for non-binary contracts (such as Multipliers). It also updates related tests for better accuracy and reliability.

**Logic improvements for contract readiness:**

* Updated the fallback logic in `contract-drawer.tsx` to use `isEnded(contract_info)` and `is_sold` in addition to `status` for determining when the contract card should be displayed, making the component more robust for different contract types.

**Test enhancements and coverage:**

* Added new test cases in `contract-drawer.spec.tsx` to verify that the contract drawer card is rendered correctly when `status` is null but either `is_expired` or `is_sold` is truthy, ensuring proper handling of multiplier contracts.
* Updated test descriptions and assertions to reflect the improved logic, and included `is_sold` in the relevant mocked contract info for more accurate tests.
* Changed user interaction tests to use `await` with `userEvent.click` for improved reliability with asynchronous events.

**Code organization:**

* Reorganized imports in `contract-drawer.tsx` for better readability and consistency.