### PR TITLE
Farabi/fix-undefined-clients-country

### DIFF
--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -1088,7 +1088,7 @@ export default class ClientStore extends BaseStore {
     }
 
     get is_eu_country() {
-        const country = this.website_status.clients_country;
+        const country = this.website_status?.clients_country;
         if (country) return isEuCountry(country);
         return false;
     }

--- a/packages/hooks/src/useGetPhoneNumberList.ts
+++ b/packages/hooks/src/useGetPhoneNumberList.ts
@@ -5,11 +5,8 @@ import { useStore } from '@deriv/stores';
 
 const useGetPhoneNumberList = () => {
     const { client } = useStore();
-    const {
-        account_settings,
-        website_status: { clients_country },
-        is_authorize,
-    } = client;
+    const { account_settings, website_status, is_authorize } = client;
+    const clients_country = website_status?.clients_country;
     const {
         data,
         isLoading: isPhoneSettingLoading,


### PR DESCRIPTION
This pull request makes a minor improvement to the `ClientStore` class by adding optional chaining when accessing `clients_country` from `website_status`. This change helps prevent errors if `website_status` is undefined.